### PR TITLE
Fix/vagrant initial setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,10 +212,16 @@ end
 # (https://www.vagrantup.com/downloads.html), because of a packaging bug:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818237
 $ sudo apt-get install vagrant virtualbox
+
 $ vagrant plugin install vagrant-hostsupdater
 $ vagrant up
+
+http://localhost:3000/ <- Frontend
+http://localhost:3000/admin/ <- Backend
+Backend-Login:
+  Username: admin@example.org
+  Password: media123
 ```
-now access http://media.ccc.vm:3000/ or http://media.ccc.vm:3000/admin/
 
 #### First Login
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,15 @@ on_restart do
 end
 ```
 
+#### Alternative: Setup with vagrant
+```# for ubuntu and debian one might want to install vagrant from upstream
+# (https://www.vagrantup.com/downloads.html), because of a packaging bug:
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818237
+$ sudo apt-get install vagrant virtualbox
+$ vagrant plugin install vagrant-hostsupdater
+$ vagrant up
+now access http://media.ccc.vm:3000/ or http://media.ccc.vm:3000/admin/
+
 #### First Login
 
 Login as user `admin@example.org` with password `media123`. Change these values after the first login.

--- a/README.md
+++ b/README.md
@@ -207,12 +207,14 @@ end
 ```
 
 #### Alternative: Setup with vagrant
-```# for ubuntu and debian one might want to install vagrant from upstream
+```
+# for ubuntu and debian one might want to install vagrant from upstream
 # (https://www.vagrantup.com/downloads.html), because of a packaging bug:
 # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=818237
 $ sudo apt-get install vagrant virtualbox
 $ vagrant plugin install vagrant-hostsupdater
 $ vagrant up
+```
 now access http://media.ccc.vm:3000/ or http://media.ccc.vm:3000/admin/
 
 #### First Login

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,13 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+required_plugins = %w( vagrant-hostsupdater )
+required_plugins.each do |plugin|
+  unless Vagrant.has_plugin? plugin
+    raise "vagrant plugin '#{plugin}' is missing, install with 'vagrant plugin install #{plugin}'"
+  end
+end
+
 # All Vagrant configuration is done below. The "2" in Vagrant.configure
 # configures the configuration version (we support older styles for
 # backwards compatibility). Please don't change it unless you know what
@@ -26,7 +33,9 @@ Vagrant.configure(2) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
+  config.vm.network "private_network", ip: "192.168.23.42"
+  config.vm.hostname = "media.ccc.vm"
+  config.hostsupdater.remove_on_suspend = true
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,7 +74,7 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-		echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+    echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
     export DEBIAN_FRONTEND="noninteractive"
     apt-get update
     apt-get install -y redis-server elasticsearch ruby2.3 ruby2.3-dev postgresql-9.5 nodejs libssl-dev build-essential libpq-dev libsqlite3-dev
@@ -83,11 +83,11 @@ Vagrant.configure(2) do |config|
     echo "create role voctoweb with createdb login password 'voctoweb';" | sudo -u postgres psql
 
     # elasticsearch
-		sed -i -e 's/#START_DAEMON/START_DAEMON/' /etc/default/elasticsearch
+    sed -i -e 's/#START_DAEMON/START_DAEMON/' /etc/default/elasticsearch
     systemctl restart elasticsearch
     cd /vagrant
     sudo gem install bundler
-		sudo -u ubuntu bin/setup
+    sudo -u ubuntu bin/setup
 
     # Puma
     tee /etc/systemd/system/voctoweb-puma.service <<UNIT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,15 +70,15 @@ Vagrant.configure(2) do |config|
     apt-get update
     apt-get install -y redis-server elasticsearch ruby2.3 ruby2.3-dev postgresql-9.5 nodejs libssl-dev build-essential libpq-dev libsqlite3-dev
 
+    # postgresql
+    echo "create role voctoweb with createdb login password 'voctoweb';" | sudo -u postgres psql
+
     # elasticsearch
 		sed -i -e 's/#START_DAEMON/START_DAEMON/' /etc/default/elasticsearch
     systemctl restart elasticsearch
     cd /vagrant
     sudo gem install bundler
 		sudo -u ubuntu bin/setup
-
-    # postgresql
-    echo "create role voctoweb with createdb login password 'voctoweb'; | sudo -u postgres psql
 
     # Puma
     tee /etc/systemd/system/voctoweb-puma.service <<UNIT

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,6 +108,7 @@ SyslogIdentifier=voctoweb-puma
 WantedBy=default.target
 UNIT
   systemctl enable voctoweb-puma
+  systemctl start voctoweb-puma
 
   SHELL
 end

--- a/bin/setup
+++ b/bin/setup
@@ -8,6 +8,7 @@ Dir.chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file:
 
+  ENV['HOME'] = '/home/ubuntu/'
   puts '== Installing dependencies =='
   system 'gem install bundler --conservative'
   system 'bundle check || bundle install --jobs=3'


### PR DESCRIPTION
Fix issues I had when setting up the development-VM for the first Time via vagrant.
Add hostupdater as a known way to access the VM (it will be always reachable via http://media.ccc.vm:3000).

Thinks I'd like to ask @manno about, before implementing them, would be
 - adding some demo-data (two congresses, maybe)
 - adding some kind of reverse proxy (which one is used on the prod box) to be able to access voctoweb via port 80 on the vm
