### PR TITLE
First time setup fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ $ vagrant plugin install vagrant-hostsupdater
 $ vagrant up
 $ vagrant ssh -c 'cd /vagrant && ./bin/update-data'
 
-http://localhost:3000/ <- Frontend
-http://localhost:3000/admin/ <- Backend
+http://media.ccc.vm:3000/ <- Frontend
+http://media.ccc.vm:3000/admin/ <- Backend
 Backend-Login:
   Username: admin@example.org
   Password: media123

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -59,6 +59,7 @@ Vagrant.configure(2) do |config|
      # Customize the amount of memory on the VM:
      vb.memory = "4096"
      vb.cpus = 4
+     vb.name = "voctoweb-dev"
   end
   #
   # View the documentation for the provider you are using for more


### PR DESCRIPTION
Small improvements from my first time setup experience using vagrant. Please consider integration.

The hostname is setup by the vagrant-hostupdater and localhost is not correct. I think proper VM names help when you are using the virtualbox UI. Exiting vagrant boxes are renamed seamlessly.