### PR TITLE
Store visitor identifiers on recording view

### DIFF
--- a/app/controllers/concerns/throttle_connections.rb
+++ b/app/controllers/concerns/throttle_connections.rb
@@ -3,28 +3,18 @@ require 'active_support/concern'
 module ThrottleConnections
   extend ActiveSupport::Concern
 
-  def throttle?(key)
+  def throttle?(recording_view)
     return false if Rails.env.test?
-    Rails.cache.exist?(cache_key(key))
+    Rails.cache.exist?(cache_key(recording_view))
   end
 
-  def add_throttling(key)
-    Rails.cache.write(cache_key(key), true, expires_in: 1.day, race_condition_ttl: 5)
+  def add_throttling(recording_view)
+    Rails.cache.write(cache_key(recording_view), true, expires_in: 12.hours, race_condition_ttl: 5)
   end
 
   private
 
-  def cache_key(key)
-    ['throttle', key, Digest::MD5.hexdigest(remote_ip)]
+  def cache_key(recording_view)
+    ['throttle', recording_view.recording.event_id, recording_view.recording.filename, recording_view.identifier]
   end
-
-  def remote_ip
-    if request.env.has_key? 'HTTP_X_FORWARDED_FOR'
-      request.env['HTTP_X_FORWARDED_FOR']
-    else
-      request.remote_ip
-    end
-  end
-
 end
-

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -1,6 +1,5 @@
 class Public::EventsController < ActionController::Base
   include ApiErrorResponses
-  include ThrottleConnections
   respond_to :json
 
   def index

--- a/app/models/recording_view.rb
+++ b/app/models/recording_view.rb
@@ -1,4 +1,11 @@
 class RecordingView < ApplicationRecord
-  validates_presence_of :recording
+  validates :recording, presence: true
   belongs_to :recording
+
+  def identifier=(val)
+    secret = Rails.cache.fetch(:recording_view_secret, expires_in: 12.hours, race_condition_ttl: 10) do
+      SecureRandom.random_bytes(16)
+    end
+    self[:identifier] = Digest::SHA1.hexdigest(val + secret)
+  end
 end

--- a/db/migrate/20170103122951_add_identifiers_to_recording_views.rb
+++ b/db/migrate/20170103122951_add_identifiers_to_recording_views.rb
@@ -1,0 +1,6 @@
+class AddIdentifiersToRecordingViews < ActiveRecord::Migration[5.0]
+  def change
+    add_column :recording_views, :user_agent, :string, default: ''
+    add_column :recording_views, :identifier, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161231215656) do
+ActiveRecord::Schema.define(version: 20170103122951) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define(version: 20161231215656) do
     t.integer  "recording_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "user_agent",   default: ""
+    t.string   "identifier",   default: ""
     t.index ["recording_id"], name: "index_recording_views_on_recording_id", using: :btree
   end
 


### PR DESCRIPTION
 Store user agent and hashed IP address on recording views.

 The IP is hashed together with a secret that's valid for 12 hours. This should in theory offer some protection against reversing it.
The new identifier is also used in the existing throttle cache.
