### PR TITLE
Rewording of the statistics claim. videos -> recordings, conferences -> events

### DIFF
--- a/app/views/frontend/home/index.html.haml
+++ b/app/views/frontend/home/index.html.haml
@@ -19,9 +19,9 @@
                 %i.icon-search
 
         %p.tagline
-          #{number_with_delimiter(@recordings_count, delimiter: ".")} files in
-          #{number_with_delimiter(@events_count, delimiter: ".")} videos at
-          #{number_with_delimiter(@conferences_count, delimiter: ".")} conferences
+          #{number_with_delimiter(@recordings_count, delimiter: ".")} files of
+          #{number_with_delimiter(@events_count, delimiter: ".")} recordings at
+          #{number_with_delimiter(@conferences_count, delimiter: ".")} events
 
     / Buttons
     .col-xs-12.col-sm-8.col-sm-push-2


### PR DESCRIPTION
In my opinion the text "_14.215 files in 3.668 videos at 99 conferences_" could be improved, since I am already associating "file" with "video" and doesn't make much sense.

Since there are not only files from conferences but also theaters or blinkenlights available I am suggesting the following:

_14.170 files of 3.661 recordings at 98 events_

The term event is already used on the start page on the button "all events" and is therefore something the user already knows.

_I am aware, that the term recording and event is used differently in the model but I think that should not be something the user has to experience and we should use words a normal user would use._