### PR TITLE
Shortened event titles for the promotion slider

### DIFF
--- a/app/models/frontend/event.rb
+++ b/app/models/frontend/event.rb
@@ -14,6 +14,12 @@ module Frontend
       self[:title].strip
     end
 
+    def short_title
+      return unless title
+      # Truncate title e.g. for slider, value was determined experimentally
+      title.truncate(40, omission: '…')
+    end
+
     def display_date
       d = release_date || date
       d.strftime('%Y-%m-%d') if d

--- a/app/views/frontend/shared/_promoted.haml
+++ b/app/views/frontend/shared/_promoted.haml
@@ -4,4 +4,4 @@
     - Frontend::Event.promoted(10).includes(:conference).each_with_index do |event, i|
       .slide
         %a.item{href: event_path(slug: event.slug), 'class' => (i == 0 and 'active')}
-          %img{src: h(event.thumb_url), alt: event.title, title: event.title}
+          %img{src: h(event.thumb_url), alt: event.title, title: event.short_title}

--- a/test/models/frontend/event_test.rb
+++ b/test/models/frontend/event_test.rb
@@ -27,4 +27,13 @@ class EventTest < ActiveSupport::TestCase
     @event.save
     assert_equal 3, @event.metadata['related'].count
   end
+
+  test 'should shorten titles using ellipsis character' do
+    @event = Frontend::Event.new
+    @event.title = "regular title"
+    assert_equal "regular title", @event.short_title
+
+    @event.title = "too long title.....20...25...30...35...40....45"
+    assert_equal "too long title.....20...25...30...35...…", @event.short_title
+  end
 end


### PR DESCRIPTION
Shortened event titles for the promotion slider to prevent the text reaching into the slider controls.

Tested in ff, chrome, android

Before:

![slider-before](https://cloud.githubusercontent.com/assets/26708/21959247/8cce6876-dac1-11e6-90e9-894f01569985.png)

After:

![slider-after](https://cloud.githubusercontent.com/assets/26708/21959246/8ccdbc82-dac1-11e6-93d8-c076c07f33be.png)
