### PR TITLE
Allow the conference view to be sorted by view count

### DIFF
--- a/app/controllers/frontend/conferences_controller.rb
+++ b/app/controllers/frontend/conferences_controller.rb
@@ -3,7 +3,8 @@ module Frontend
     SORT_PARAM = {
       'name' => 'title',
       'duration' => 'duration',
-      'date' => 'date desc, release_date desc'
+      'date' => 'date desc, release_date desc',
+      'view_count' => 'view_count desc'
     }.freeze
 
     before_action :check_sort_param, only: %w(show)

--- a/app/views/frontend/conferences/show.html.haml
+++ b/app/views/frontend/conferences/show.html.haml
@@ -13,11 +13,11 @@
       %h2= @conference.acronym.gsub(/[\-_]/,' ')
 
     #sorting.btn-group.btn-group-sm.btn-group-justified
-      - %w{name duration date}.each do |sorting|
+      - %w{name duration date view_count}.each do |sorting|
         - if @sorting == sorting
-          %a.btn.btn-primary.active{ href: conference_path(acronym: @conference.acronym, sort: sorting) }= sorting
+          %a.btn.btn-primary.active{ href: conference_path(acronym: @conference.acronym, sort: sorting) }= sorting.gsub(/_/, ' ')
         - else
-          %a.btn.btn-primary{ href: conference_path(acronym: @conference.acronym, sort: sorting) }= sorting
+          %a.btn.btn-primary{ href: conference_path(acronym: @conference.acronym, sort: sorting) }= sorting.gsub(/_/, ' ')
 
   - if @events.present?
     .event-previews

--- a/app/views/frontend/shared/_event_metadata.haml
+++ b/app/views/frontend/shared/_event_metadata.haml
@@ -14,5 +14,8 @@
     %li.date
       %span.icon.icon-calendar-o
       = event.display_date
+    %li.view-count
+      %span.icon.icon-eye
+      = event.view_count
     %li.persons
       = render partial: 'frontend/shared/event_persons', locals: { persons: event.persons }


### PR DESCRIPTION
See #196. Here's my rationale for putting the attributes in the order "date - view_count - people": The eye icons line up, and you can compare the numbers more easily. If you put the view count last, there's more visual noise. 

![screenshot](https://cloud.githubusercontent.com/assets/81277/22398156/6a3499ea-e582-11e6-90cf-a78e8b200b27.png)
