### PR TITLE
Fix positioning of "Download subtitle" button

### DIFF
--- a/app/assets/stylesheets/frontend/pages/_show.scss
+++ b/app/assets/stylesheets/frontend/pages/_show.scss
@@ -182,6 +182,9 @@ body.page-show {
         display: block;
         float: left;
       }
+      .onlyone {
+        float: left;
+      }
       .improve {
         display: block;
         float: left;


### PR DESCRIPTION
See #209. It was missing the "float: left" property when it wasn't part of a subtitle dropdown box.