### PR TITLE
#235 Use event date instead of publish date for display and recent event list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ config/settings.yml
 # sublimetext project files
 /*.sublime-project
 /*.sublime-workspace
+
+# vim
+*.swp

--- a/app/assets/stylesheets/frontend/pages/_show.scss
+++ b/app/assets/stylesheets/frontend/pages/_show.scss
@@ -18,7 +18,7 @@ body.page-show {
 
     li {
       display: inline-block;
-      min-width: 24.5%;
+      min-width: 18%;
       padding: $padding-small-vertical $padding-small-horizontal;
     }
 

--- a/app/helpers/frontend/application_helper.rb
+++ b/app/helpers/frontend/application_helper.rb
@@ -116,7 +116,8 @@ module Frontend
       end
     end
 
-    def display_date_title(event)
+    def display_release_date_title(event)
+      return 'event and release date' if event.released_on_event_day?
       return 'event date' if event.date
       'video release date'
     end

--- a/app/models/frontend/event.rb
+++ b/app/models/frontend/event.rb
@@ -1,4 +1,6 @@
 module Frontend
+  require "date"
+
   class Event < ::Event
     index_name "media-event-#{Rails.env}"
     document_type 'event'
@@ -21,8 +23,12 @@ module Frontend
     end
 
     def display_date
-      d = release_date || date
+      d = date || release_date
       d.strftime('%Y-%m-%d') if d
+    end
+
+    def released_on_event_day?
+      date && date.to_date === release_date.to_date
     end
 
     def poster_url

--- a/app/views/frontend/events/show.html.haml
+++ b/app/views/frontend/events/show.html.haml
@@ -41,8 +41,12 @@
         %span.icon.icon-clock-o
         = duration_in_minutes(@event.duration)
       %li
-        %span.icon.icon-calendar-o{title: display_date_title(@event)}
+        %span.icon.icon-calendar-o{title: display_release_date_title(@event)}
         = @event.display_date
+      - if ! @event.released_on_event_day?
+        %li
+          %span.icon.icon-upload{title: 'release date'}
+          = @event.release_date 
       %li
         %span.icon.icon-eye
         = @event.view_count

--- a/app/views/frontend/home/index.html.haml
+++ b/app/views/frontend/home/index.html.haml
@@ -41,7 +41,7 @@
 
     .col-xs-12.recently
       .headline
-        %h2 Recently published
+        %h2 Recently added
         %a{href: recent_path}
           More recent videos
 
@@ -63,7 +63,7 @@
                       %a.title{href: event_path(slug: event.slug), title: event.title.length > 55 ? event.title : ''}
                         = truncate(event.title, length: 55, separator: ' ', omission: '…')
                       .date
-                        %span.icon.icon-calendar-o{title: display_date_title(event)}
+                        %span.icon.icon-calendar-o{title: display_release_date_title(event)}
                         = event.display_date
 
 


### PR DESCRIPTION
Fixing #235

you could argue about sorting of the most recent conferences list on the main page. It would now obey the event date too.

Any comments on that? (FYI @derpeter)

After this would be deployed we could update the conference last released date using a "batch job".

One could argue we should refactor the "event_last_released_at" column. Any comments on that, is it worth it?