### PR TITLE
Sort the conference view by "view count" by default

### DIFF
--- a/app/controllers/frontend/conferences_controller.rb
+++ b/app/controllers/frontend/conferences_controller.rb
@@ -47,7 +47,7 @@ module Frontend
 
     def sort_param
       return SORT_PARAM[@sorting] if @sorting
-      'date desc, release_date desc'
+      'view_count desc'
     end
 
     def check_sort_param


### PR DESCRIPTION
This should make it easier for people to find talks deemed popular by other users, highlighting quality content.

In a quick user study, I found that nobody ever noticed/knew about the top menu with different sorting options.