### PR TITLE
adds Android TV App to apps section on about page

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -67,6 +67,9 @@
       %a{href: 'https://github.com/cccc/MediaCCC.bundle'} Plex plugin (not released yet)
     %li
       :markdown
+        [Android TV App](https://github.com/stefanmedack/cccTV). Runs on Android TV and Fire TV. Tablet support in progress.
+    %li
+      :markdown
         [AppleTV app](https://github.com/ccc-ffm/CCC-TV). Not all talks available due to Apple Inc. a employee's interpretation of their [app store review guidlines](https://developer.apple.com/app-store/review/guidelines/)
     %li
       :markdown


### PR DESCRIPTION
Hey there,

It was a little disapointing to see that there was an Apple TV but no Android TV App, so I built one in my spare time. I would appreciate a mentioning on the listed Apps section on the about page ;)