### PR TITLE
Live stream promotion styling

### DIFF
--- a/app/assets/stylesheets/frontend/shared/_promoted.scss
+++ b/app/assets/stylesheets/frontend/shared/_promoted.scss
@@ -6,14 +6,20 @@
   position: relative;
 
   &.live {
-    height: 380px;
+    @media #{$lg-or-bigger} {
+      height: 380px;
+    }
 
     h2 {
       color: white;
       border-bottom: 0;
-      font-size: 70px;
       text-shadow: white 0 0 5px;
-      margin: 30px 0 0 0;
+      margin: 20px 0 0 0;
+
+      @media #{$lg-or-bigger} {
+        font-size: 70px;
+        margin: 30px 0 0 0;
+      }
     }
   }
 

--- a/app/assets/stylesheets/frontend/shared/_promoted.scss
+++ b/app/assets/stylesheets/frontend/shared/_promoted.scss
@@ -4,6 +4,19 @@
   overflow: hidden;
   text-align: center;
   position: relative;
+
+  &.live {
+    height: 380px;
+
+    h2 {
+      color: white;
+      border-bottom: 0;
+      font-size: 70px;
+      text-shadow: white 0 0 5px;
+      margin: 30px 0 0 0;
+    }
+  }
+
   .carousel-inner {
     height: 100%;
   }

--- a/app/models/frontend/conference.rb
+++ b/app/models/frontend/conference.rb
@@ -25,6 +25,10 @@ module Frontend
       Conference.where('streaming ? :key', key: 'groups').any?
     end
 
+    def self.first_live
+      Conference.where('streaming ? :key', key: 'groups').first
+    end
+
     def self.live
       conferences = Conference.where('streaming ? :key', key: 'groups')
       groups = conferences.map { |c| c.streaming['groups'].first }.compact

--- a/app/views/frontend/shared/_live.html.haml
+++ b/app/views/frontend/shared/_live.html.haml
@@ -1,4 +1,5 @@
-.promoted.themed-banner
+.promoted.themed-banner.live
+  %h2= "Live now – " + Frontend::Conference.first_live.title
   .titlebar
   .slider
     - Frontend::Conference.live.each_with_index do |event, i|


### PR DESCRIPTION
Before:
![screenshot from 2017-11-14 23-13-39](https://user-images.githubusercontent.com/142237/32807884-af2ae4b6-c991-11e7-95d0-bc323dea760a.png)


After:
![screenshot from 2017-11-14 23-11-57](https://user-images.githubusercontent.com/142237/32807889-b13a1d3a-c991-11e7-8fd3-883eb7bd6721.png)
