### PR TITLE
Version all inheritances of ActiveRecord::Migration

### DIFF
--- a/db/migrate/20130820182037_devise_create_admin_users.rb
+++ b/db/migrate/20130820182037_devise_create_admin_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateAdminUsers < ActiveRecord::Migration
+class DeviseCreateAdminUsers < ActiveRecord::Migration[4.2]
   def migrate(direction)
     super
     # Create a default user

--- a/db/migrate/20130820182039_create_active_admin_comments.rb
+++ b/db/migrate/20130820182039_create_active_admin_comments.rb
@@ -1,4 +1,4 @@
-class CreateActiveAdminComments < ActiveRecord::Migration
+class CreateActiveAdminComments < ActiveRecord::Migration[4.2]
   def self.up
     create_table :active_admin_comments do |t|
       t.string :namespace

--- a/db/migrate/20130820192118_create_conferences.rb
+++ b/db/migrate/20130820192118_create_conferences.rb
@@ -1,4 +1,4 @@
-class CreateConferences < ActiveRecord::Migration
+class CreateConferences < ActiveRecord::Migration[4.2]
   def change
     create_table :conferences do |t|
       t.string :acronym

--- a/db/migrate/20130820210349_create_api_keys.rb
+++ b/db/migrate/20130820210349_create_api_keys.rb
@@ -1,4 +1,4 @@
-class CreateApiKeys < ActiveRecord::Migration
+class CreateApiKeys < ActiveRecord::Migration[4.2]
   def change
     create_table :api_keys do |t|
       t.string :key

--- a/db/migrate/20130820221709_add_conference_indexes.rb
+++ b/db/migrate/20130820221709_add_conference_indexes.rb
@@ -1,4 +1,4 @@
-class AddConferenceIndexes < ActiveRecord::Migration
+class AddConferenceIndexes < ActiveRecord::Migration[4.2]
   def up
     add_index :conferences, :acronym
   end

--- a/db/migrate/20130820222430_create_events.rb
+++ b/db/migrate/20130820222430_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :events do |t|
       t.string :guid

--- a/db/migrate/20130820222724_create_recordings.rb
+++ b/db/migrate/20130820222724_create_recordings.rb
@@ -1,4 +1,4 @@
-class CreateRecordings < ActiveRecord::Migration
+class CreateRecordings < ActiveRecord::Migration[4.2]
   def change
     create_table :recordings do |t|
       t.integer :size

--- a/db/migrate/20130820223153_add_path_to_recording.rb
+++ b/db/migrate/20130820223153_add_path_to_recording.rb
@@ -1,4 +1,4 @@
-class AddPathToRecording < ActiveRecord::Migration
+class AddPathToRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :path, :string
   end

--- a/db/migrate/20130820233230_add_title_to_conference.rb
+++ b/db/migrate/20130820233230_add_title_to_conference.rb
@@ -1,4 +1,4 @@
-class AddTitleToConference < ActiveRecord::Migration
+class AddTitleToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :title, :string
   end

--- a/db/migrate/20130820233237_add_title_to_event.rb
+++ b/db/migrate/20130820233237_add_title_to_event.rb
@@ -1,4 +1,4 @@
-class AddTitleToEvent < ActiveRecord::Migration
+class AddTitleToEvent < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :title, :string
   end

--- a/db/migrate/20130820233659_add_indexes_to_events.rb
+++ b/db/migrate/20130820233659_add_indexes_to_events.rb
@@ -1,4 +1,4 @@
-class AddIndexesToEvents < ActiveRecord::Migration
+class AddIndexesToEvents < ActiveRecord::Migration[4.2]
   def change
     add_index :events, :guid
     add_index :events, :title

--- a/db/migrate/20130820233759_add_indexes_to_recordings.rb
+++ b/db/migrate/20130820233759_add_indexes_to_recordings.rb
@@ -1,4 +1,4 @@
-class AddIndexesToRecordings < ActiveRecord::Migration
+class AddIndexesToRecordings < ActiveRecord::Migration[4.2]
   def change
     add_index :recordings, :path
     add_index :recordings, :mime_type

--- a/db/migrate/20130821000003_add_recording_states.rb
+++ b/db/migrate/20130821000003_add_recording_states.rb
@@ -1,4 +1,4 @@
-class AddRecordingStates < ActiveRecord::Migration
+class AddRecordingStates < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :state, :string, default: "new", null: false
     add_index :events, :state

--- a/db/migrate/20130821121327_create_delayed_jobs.rb
+++ b/db/migrate/20130821121327_create_delayed_jobs.rb
@@ -1,4 +1,4 @@
-class CreateDelayedJobs < ActiveRecord::Migration
+class CreateDelayedJobs < ActiveRecord::Migration[4.2]
   def self.up
     create_table :delayed_jobs, :force => true do |table|
       table.integer  :priority, :default => 0, :null => false # Allows some jobs to jump to the front of the queue

--- a/db/migrate/20130821123704_create_event_infos.rb
+++ b/db/migrate/20130821123704_create_event_infos.rb
@@ -1,4 +1,4 @@
-class CreateEventInfos < ActiveRecord::Migration
+class CreateEventInfos < ActiveRecord::Migration[4.2]
   def change
     create_table :event_infos do |t|
       t.references :event, index: true

--- a/db/migrate/20130821124234_add_schedule_url_to_conference.rb
+++ b/db/migrate/20130821124234_add_schedule_url_to_conference.rb
@@ -1,4 +1,4 @@
-class AddScheduleUrlToConference < ActiveRecord::Migration
+class AddScheduleUrlToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :schedule_url, :string
     add_column :conferences, :schedule_xml, :binary

--- a/db/migrate/20130822181227_change_recording_model.rb
+++ b/db/migrate/20130822181227_change_recording_model.rb
@@ -1,4 +1,4 @@
-class ChangeRecordingModel < ActiveRecord::Migration
+class ChangeRecordingModel < ActiveRecord::Migration[4.2]
   def change
     rename_column :recordings, :path, :filename
     add_column :recordings, :original_url, :string

--- a/db/migrate/20130824135552_add_thumb_filename_to_event.rb
+++ b/db/migrate/20130824135552_add_thumb_filename_to_event.rb
@@ -1,4 +1,4 @@
-class AddThumbFilenameToEvent < ActiveRecord::Migration
+class AddThumbFilenameToEvent < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :thumb_filename, :string
   end

--- a/db/migrate/20130826215505_add_slug_to_event_info.rb
+++ b/db/migrate/20130826215505_add_slug_to_event_info.rb
@@ -1,4 +1,4 @@
-class AddSlugToEventInfo < ActiveRecord::Migration
+class AddSlugToEventInfo < ActiveRecord::Migration[4.2]
   def change
     add_column :event_infos, :slug, :string
   end

--- a/db/migrate/20140101230549_add_event_info_fields_to_event.rb
+++ b/db/migrate/20140101230549_add_event_info_fields_to_event.rb
@@ -1,4 +1,4 @@
-class AddEventInfoFieldsToEvent < ActiveRecord::Migration
+class AddEventInfoFieldsToEvent < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :date, :date
     add_column :events, :description, :text

--- a/db/migrate/20140101231325_move_event_info_data_to_event.rb
+++ b/db/migrate/20140101231325_move_event_info_data_to_event.rb
@@ -1,4 +1,4 @@
-class MoveEventInfoDataToEvent < ActiveRecord::Migration
+class MoveEventInfoDataToEvent < ActiveRecord::Migration[4.2]
 
   def up
     EventInfo.all.each do |ei|

--- a/db/migrate/20140101232111_remove_event_info_table.rb
+++ b/db/migrate/20140101232111_remove_event_info_table.rb
@@ -1,4 +1,4 @@
-class RemoveEventInfoTable < ActiveRecord::Migration
+class RemoveEventInfoTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :event_infos
   end

--- a/db/migrate/20140102031811_add_conference_logo.rb
+++ b/db/migrate/20140102031811_add_conference_logo.rb
@@ -1,4 +1,4 @@
-class AddConferenceLogo < ActiveRecord::Migration
+class AddConferenceLogo < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :logo, :string
   end

--- a/db/migrate/20140103000033_add_folder_to_recording.rb
+++ b/db/migrate/20140103000033_add_folder_to_recording.rb
@@ -1,4 +1,4 @@
-class AddFolderToRecording < ActiveRecord::Migration
+class AddFolderToRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :folder, :string
   end

--- a/db/migrate/20140103000127_fill_recordings_folder_from_mime_types.rb
+++ b/db/migrate/20140103000127_fill_recordings_folder_from_mime_types.rb
@@ -1,4 +1,4 @@
-class FillRecordingsFolderFromMimeTypes < ActiveRecord::Migration
+class FillRecordingsFolderFromMimeTypes < ActiveRecord::Migration[4.2]
 
   def up
     mappings = {

--- a/db/migrate/20140120020012_add_release_date_to_event.rb
+++ b/db/migrate/20140120020012_add_release_date_to_event.rb
@@ -1,4 +1,4 @@
-class AddReleaseDateToEvent < ActiveRecord::Migration
+class AddReleaseDateToEvent < ActiveRecord::Migration[4.2]
   def up
     add_column :events, :release_date, :datetime
     Event.all.each { |e|

--- a/db/migrate/20140502191657_add_dimensions_to_recording.rb
+++ b/db/migrate/20140502191657_add_dimensions_to_recording.rb
@@ -1,4 +1,4 @@
-class AddDimensionsToRecording < ActiveRecord::Migration
+class AddDimensionsToRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :width, :integer
     add_column :recordings, :height, :integer

--- a/db/migrate/20140502222555_add_promoted_flag_to_events.rb
+++ b/db/migrate/20140502222555_add_promoted_flag_to_events.rb
@@ -1,4 +1,4 @@
-class AddPromotedFlagToEvents < ActiveRecord::Migration
+class AddPromotedFlagToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :promoted, :boolean
   end

--- a/db/migrate/20140502223824_create_news.rb
+++ b/db/migrate/20140502223824_create_news.rb
@@ -1,4 +1,4 @@
-class CreateNews < ActiveRecord::Migration
+class CreateNews < ActiveRecord::Migration[4.2]
   def change
     create_table :news do |t|
       t.string :title

--- a/db/migrate/20140609012419_create_import_templates.rb
+++ b/db/migrate/20140609012419_create_import_templates.rb
@@ -1,4 +1,4 @@
-class CreateImportTemplates < ActiveRecord::Migration
+class CreateImportTemplates < ActiveRecord::Migration[4.2]
   def change
     create_table :import_templates do |t|
 

--- a/db/migrate/20140611215347_remove_promoted_from_import_template.rb
+++ b/db/migrate/20140611215347_remove_promoted_from_import_template.rb
@@ -1,4 +1,4 @@
-class RemovePromotedFromImportTemplate < ActiveRecord::Migration
+class RemovePromotedFromImportTemplate < ActiveRecord::Migration[4.2]
   def up
     remove_column :import_templates, :promoted
   end

--- a/db/migrate/20140611215723_change_release_date_to_date.rb
+++ b/db/migrate/20140611215723_change_release_date_to_date.rb
@@ -1,4 +1,4 @@
-class ChangeReleaseDateToDate < ActiveRecord::Migration
+class ChangeReleaseDateToDate < ActiveRecord::Migration[4.2]
   def up
     change_column :import_templates, :release_date, :date
     change_column :events, :release_date, :date

--- a/db/migrate/20140615151738_change_conference_schedule_xml_to_text.rb
+++ b/db/migrate/20140615151738_change_conference_schedule_xml_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeConferenceScheduleXmlToText < ActiveRecord::Migration
+class ChangeConferenceScheduleXmlToText < ActiveRecord::Migration[4.2]
   def up
     change_column :conferences, :schedule_xml, :text, limit: 10.megabyte
   end

--- a/db/migrate/20140622020440_add_view_count_to_events.rb
+++ b/db/migrate/20140622020440_add_view_count_to_events.rb
@@ -1,4 +1,4 @@
-class AddViewCountToEvents < ActiveRecord::Migration
+class AddViewCountToEvents < ActiveRecord::Migration[4.2]
 
   def up
     add_column :events, :view_count, :integer, default: 0

--- a/db/migrate/20140622085720_remove_released_state_from_recording.rb
+++ b/db/migrate/20140622085720_remove_released_state_from_recording.rb
@@ -1,4 +1,4 @@
-class RemoveReleasedStateFromRecording < ActiveRecord::Migration
+class RemoveReleasedStateFromRecording < ActiveRecord::Migration[4.2]
   def up
     execute %{
     UPDATE recordings SET state='downloaded' WHERE state='released'

--- a/db/migrate/20140626220827_create_recording_views.rb
+++ b/db/migrate/20140626220827_create_recording_views.rb
@@ -1,4 +1,4 @@
-class CreateRecordingViews < ActiveRecord::Migration
+class CreateRecordingViews < ActiveRecord::Migration[4.2]
   def change
     create_table :recording_views do |t|
       t.references :recording, index: true

--- a/db/migrate/20140626223140_add_view_count_to_recordings.rb
+++ b/db/migrate/20140626223140_add_view_count_to_recordings.rb
@@ -1,4 +1,4 @@
-class AddViewCountToRecordings < ActiveRecord::Migration
+class AddViewCountToRecordings < ActiveRecord::Migration[4.2]
   def up
     add_column :recordings, :view_count, :integer, default: 0
 

--- a/db/migrate/20140627185401_remove_view_count_from_recordings.rb
+++ b/db/migrate/20140627185401_remove_view_count_from_recordings.rb
@@ -1,4 +1,4 @@
-class RemoveViewCountFromRecordings < ActiveRecord::Migration
+class RemoveViewCountFromRecordings < ActiveRecord::Migration[4.2]
   def up
     remove_column :recordings, :view_count
   end

--- a/db/migrate/20140907121133_remove_event_gif.rb
+++ b/db/migrate/20140907121133_remove_event_gif.rb
@@ -1,4 +1,4 @@
-class RemoveEventGif < ActiveRecord::Migration
+class RemoveEventGif < ActiveRecord::Migration[4.2]
   def change
     remove_column :events, :gif_filename
   end

--- a/db/migrate/20141111120848_add_time_to_event_date.rb
+++ b/db/migrate/20141111120848_add_time_to_event_date.rb
@@ -1,4 +1,4 @@
-class AddTimeToEventDate < ActiveRecord::Migration
+class AddTimeToEventDate < ActiveRecord::Migration[4.2]
   def change
     change_column :events, :date, :datetime
   end

--- a/db/migrate/20150913230424_drop_delayed_jobs_table.rb
+++ b/db/migrate/20150913230424_drop_delayed_jobs_table.rb
@@ -1,4 +1,4 @@
-class DropDelayedJobsTable < ActiveRecord::Migration
+class DropDelayedJobsTable < ActiveRecord::Migration[4.2]
   def change
     drop_table :delayed_jobs
   end

--- a/db/migrate/20150919123544_rename_conference_webgen_location_to_slug.rb
+++ b/db/migrate/20150919123544_rename_conference_webgen_location_to_slug.rb
@@ -1,4 +1,4 @@
-class RenameConferenceWebgenLocationToSlug < ActiveRecord::Migration
+class RenameConferenceWebgenLocationToSlug < ActiveRecord::Migration[4.2]
   def change
     rename_column :conferences, :webgen_location, :slug
     change_column :conferences, :slug, :string, default: ''

--- a/db/migrate/20150919124229_rename_import_template_webgen_location_to_slug.rb
+++ b/db/migrate/20150919124229_rename_import_template_webgen_location_to_slug.rb
@@ -1,4 +1,4 @@
-class RenameImportTemplateWebgenLocationToSlug < ActiveRecord::Migration
+class RenameImportTemplateWebgenLocationToSlug < ActiveRecord::Migration[4.2]
   def change
     rename_column :import_templates, :webgen_location, :slug
   end

--- a/db/migrate/20151011213109_add_duration_to_event.rb
+++ b/db/migrate/20151011213109_add_duration_to_event.rb
@@ -1,4 +1,4 @@
-class AddDurationToEvent < ActiveRecord::Migration
+class AddDurationToEvent < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :duration, :integer, default: 0
     Event.find_each do |event|

--- a/db/migrate/20151018212350_add_downloaded_events_count_to_conferences.rb
+++ b/db/migrate/20151018212350_add_downloaded_events_count_to_conferences.rb
@@ -1,4 +1,4 @@
-class AddDownloadedEventsCountToConferences < ActiveRecord::Migration
+class AddDownloadedEventsCountToConferences < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :downloaded_events_count, :integer, default: 0, null: false
     Conference.reset_column_information

--- a/db/migrate/20151027160631_add_indexes.rb
+++ b/db/migrate/20151027160631_add_indexes.rb
@@ -1,4 +1,4 @@
-class AddIndexes < ActiveRecord::Migration
+class AddIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index 'events', ['slug'], name: 'index_events_on_slug'
     add_index 'events', ['release_date'], name: 'index_events_on_release_date'

--- a/db/migrate/20151105165721_add_downloaded_recordings_counter_on_events.rb
+++ b/db/migrate/20151105165721_add_downloaded_recordings_counter_on_events.rb
@@ -1,4 +1,4 @@
-class AddDownloadedRecordingsCounterOnEvents < ActiveRecord::Migration
+class AddDownloadedRecordingsCounterOnEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :downloaded_recordings_count, :integer, default: 0
     Event.reset_column_information

--- a/db/migrate/20151227115938_add_language_string_to_recording.rb
+++ b/db/migrate/20151227115938_add_language_string_to_recording.rb
@@ -1,4 +1,4 @@
-class AddLanguageStringToRecording < ActiveRecord::Migration
+class AddLanguageStringToRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :language, :string, default: 'en'
   end

--- a/db/migrate/20151230105406_add_original_language_to_event.rb
+++ b/db/migrate/20151230105406_add_original_language_to_event.rb
@@ -1,4 +1,4 @@
-class AddOriginalLanguageToEvent < ActiveRecord::Migration
+class AddOriginalLanguageToEvent < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :original_language, :string
 

--- a/db/migrate/20160102191700_add_quality_flag_on_recording.rb
+++ b/db/migrate/20160102191700_add_quality_flag_on_recording.rb
@@ -1,4 +1,4 @@
-class AddQualityFlagOnRecording < ActiveRecord::Migration
+class AddQualityFlagOnRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :hd_quality, :boolean, default: true, null: false
   end

--- a/db/migrate/20160102191709_add_html5_flag_on_recording.rb
+++ b/db/migrate/20160102191709_add_html5_flag_on_recording.rb
@@ -1,4 +1,4 @@
-class AddHtml5FlagOnRecording < ActiveRecord::Migration
+class AddHtml5FlagOnRecording < ActiveRecord::Migration[4.2]
   def change
     add_column :recordings, :html5, :boolean, default: false, null: false
   end

--- a/db/migrate/20160102232606_drop_import_templates.rb
+++ b/db/migrate/20160102232606_drop_import_templates.rb
@@ -1,4 +1,4 @@
-class DropImportTemplates < ActiveRecord::Migration
+class DropImportTemplates < ActiveRecord::Migration[4.2]
   def change
     drop_table :import_templates
   end

--- a/db/migrate/20160104122727_mime_types_to_flags.rb
+++ b/db/migrate/20160104122727_mime_types_to_flags.rb
@@ -1,4 +1,4 @@
-class MimeTypesToFlags < ActiveRecord::Migration
+class MimeTypesToFlags < ActiveRecord::Migration[4.2]
   def change
     html5 = %w(vnd.voc/mp4-web vnd.voc/webm-web)
     Recording.find_each do |recording|

--- a/db/migrate/20160130001036_remove_original_url.rb
+++ b/db/migrate/20160130001036_remove_original_url.rb
@@ -1,4 +1,4 @@
-class RemoveOriginalUrl < ActiveRecord::Migration
+class RemoveOriginalUrl < ActiveRecord::Migration[4.2]
   def change
     remove_column :recordings, :original_url
   end

--- a/db/migrate/20160203134927_high_quality.rb
+++ b/db/migrate/20160203134927_high_quality.rb
@@ -1,4 +1,4 @@
-class HighQuality < ActiveRecord::Migration
+class HighQuality < ActiveRecord::Migration[4.2]
   def change
     rename_column :recordings, :hd_quality, :high_quality
   end

--- a/db/migrate/20160205214028_default_language_is_eng.rb
+++ b/db/migrate/20160205214028_default_language_is_eng.rb
@@ -1,4 +1,4 @@
-class DefaultLanguageIsEng < ActiveRecord::Migration
+class DefaultLanguageIsEng < ActiveRecord::Migration[4.2]
   def change
     change_column :recordings, :language, :string, default: 'eng'
   end

--- a/db/migrate/20160827151338_add_metadata_to_conference.rb
+++ b/db/migrate/20160827151338_add_metadata_to_conference.rb
@@ -1,4 +1,4 @@
-class AddMetadataToConference < ActiveRecord::Migration
+class AddMetadataToConference < ActiveRecord::Migration[4.2]
   def change
     add_column :conferences, :metadata, :jsonb, index: true, default: {}
   end


### PR DESCRIPTION
Migrations starting from Rails 5.1 will fail with
'Directly inheriting from ActiveRecord::Migration is not supported'.

Using 4.2 is a rather arbitrary, but seemingly safe choice.