### PR TITLE
Use privacy aware DNS server instead of Google's for Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -76,7 +76,7 @@ Vagrant.configure(2) do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    echo "nameserver 8.8.8.8" | sudo tee /etc/resolv.conf
+    echo "nameserver 213.73.91.35" | sudo tee /etc/resolv.conf
     export DEBIAN_FRONTEND="noninteractive"
     apt-get update
     apt-get install -y redis-server elasticsearch ruby2.3 ruby2.3-dev postgresql-9.5 nodejs libssl-dev build-essential libpq-dev libsqlite3-dev nginx


### PR DESCRIPTION
This replaces the Google public DNS server with dnscache.berlin.ccc.de (213.73.91.35), a public DNS server provided by the Berlin CCC group. I personally found this to be very reliable. For more information, see e.g,. https://www.ccc.de/de/censorship/dns-howto.