### PR TITLE
Decreased font-size in bx-slider titles since it does not look nice w…

### DIFF
--- a/app/assets/stylesheets/jquery.bxslider.css.scss
+++ b/app/assets/stylesheets/jquery.bxslider.css.scss
@@ -179,6 +179,6 @@ ul.bxslider {
   color: #fff;
   font-family: Arial;
   display: block;
-  font-size: .85em;
-  padding: 10px;
+  font-size: 20px;
+  padding: 5px;
 }


### PR DESCRIPTION
…ith the recent long titles

![4_072](https://user-images.githubusercontent.com/26708/40142425-d4630cde-5958-11e8-9905-c35990f07813.png)

Seems to help a little bit – but the concept has a problem with the length of a lot of titles. Alternative ideas?