### PR TITLE
Remove database ID from public JSON URLs

### DIFF
--- a/app/views/public/shared/_conference.json.jbuilder
+++ b/app/views/public/shared/_conference.json.jbuilder
@@ -3,4 +3,4 @@ json.webgen_location conference.slug
 json.logo_url conference.logo_url
 json.images_url conference.get_images_url
 json.recordings_url conference.get_recordings_url
-json.url public_conference_url(conference, format: :json)
+json.url public_conference_url(id: conference.acronym, format: :json)

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -8,6 +8,6 @@ json.url public_event_url(id: event.guid, format: :json)
 json.conference_url public_conference_url(id: event.conference.acronym, format: :json)
 json.related(event.metadata['related']) do |id, weight|
   json.event_id id
-  json.event_slug Event.find(id)&.slug
+  json.event_guid Event.find(id)&.guid
   json.weight weight
 end

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! event, :guid, :title, :subtitle, :slug, :link, :description, :original_language, :persons, :tags, :view_count, :promoted, :metadata, :date, :release_date, :updated_at
+json.extract! event, :guid, :title, :subtitle, :slug, :link, :description, :original_language, :persons, :tags, :view_count, :promoted, :date, :release_date, :updated_at
 json.length event.duration
 json.duration event.duration
 json.thumb_url event.get_thumb_url

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -4,9 +4,10 @@ json.duration event.duration
 json.thumb_url event.get_thumb_url
 json.poster_url event.get_poster_url
 json.frontend_link frontend_event_url(slug: event.slug)
-json.url public_event_url(event, format: :json)
-json.conference_url public_conference_url(event.conference, format: :json)
+json.url public_event_url(id: event.guid, format: :json)
+json.conference_url public_conference_url(id: event.conference.acronym, format: :json)
 json.related(event.metadata['related']) do |id, weight|
   json.event_id id
+  json.event_slug Event.find(id)&.slug
   json.weight weight
 end

--- a/app/views/public/shared/_recording.json.jbuilder
+++ b/app/views/public/shared/_recording.json.jbuilder
@@ -1,5 +1,5 @@
 json.extract! recording, :size, :length, :mime_type, :language, :filename, :state, :folder, :high_quality, :width, :height, :updated_at
 json.recording_url recording.get_recording_url
 json.url public_recording_url(recording, format: :json)
-json.event_url public_event_url(recording.event, format: :json)
-json.conference_url public_conference_url(recording.conference, format: :json)
+json.event_url public_event_url(id: recording.event.guid, format: :json)
+json.conference_url public_conference_url(id: recording.conference.acronym, format: :json)


### PR DESCRIPTION
Having database IDs in some places, but not supporting them throughout
the API is confusing.

* add slug to related events metadata, remove id in a later commit
* generated urls use guid for events
* generated urls use acronym for conferences
* recordings still use database ID