### PR TITLE
Add Timelens support, to improve video navigation capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,15 @@ However folders and access rights need to be setup manually, before you can uplo
         }
       }' "http://localhost:3000/api/conferences"
 
-You can add images to an event, like the poster image. The event is identified by its `guid` and the conference `acronym`.
+You can add images to an event, like the poster image. The event is identified by its `guid` and the conference `acronym`. For an explanation what the `timeline_url` and `thumbnails_url` parameters are, see <https://timelens.io>.
 
     curl -H "CONTENT-TYPE: application/json" -d '{
         "api_key":"4",
         "acronym":"frab123",
         "poster_url":"http://koeln.ccc.de/images/chaosknoten_preview.jpg",
         "thumb_url":"http://koeln.ccc.de/images/chaosknoten.jpg",
+        "timeline_url":"http://koeln.ccc.de/images/chaosknoten.timeline.jpg",
+        "thumbnails_url":"http://koeln.ccc.de/images/chaosknoten.thumbnails.vtt",
         "event":{
           "guid":"123",
           "slug":"123",

--- a/app/admin/event.rb
+++ b/app/admin/event.rb
@@ -20,6 +20,12 @@ ActiveAdmin.register Event do
     column :poster_filename do |event|
       line_break_filename event.poster_filename
     end
+    column :timeline_filename do |event|
+      line_break_filename event.timeline_filename
+    end
+    column :thumbnails_filename do |event|
+      line_break_filename event.thumbnails_filename
+    end
     column :original_language
     column :conference
     column :promoted
@@ -38,6 +44,12 @@ ActiveAdmin.register Event do
       end
       row :poster_filename do
         div show_event_folder e, :poster_filename
+      end
+      row :timeline_filename do
+        div show_event_folder e, :timeline_filename
+      end
+      row :thumbnails_filename do
+        div show_event_folder e, :thumbnails_filename
       end
       row :conference
       row :original_language
@@ -102,6 +114,8 @@ ActiveAdmin.register Event do
       f.input :slug
       f.input :thumb_filename, hint: event.try(:conference).try(:get_images_path)
       f.input :poster_filename, hint: event.try(:conference).try(:get_images_path)
+      f.input :timeline_filename, hint: event.try(:conference).try(:get_images_path)
+      f.input :thumbnails_filename, hint: event.try(:conference).try(:get_images_path)
     end
     f.actions
   end
@@ -139,7 +153,7 @@ ActiveAdmin.register Event do
 
   controller do
     def permitted_params
-      params.permit event: [:guid, :thumb_filename, :poster_filename,
+      params.permit event: [:guid, :thumb_filename, :poster_filename, :timeline_filename, :thumbnails_filename,
                             :conference_id, :promoted, :title, :subtitle, :link, :slug,
                             :original_language,
                             :description, :persons_raw, :tags_raw, :date, :release_date, :event_id]

--- a/app/assets/javascripts/activate-timelens.js
+++ b/app/assets/javascripts/activate-timelens.js
@@ -1,0 +1,13 @@
+$(document).on("turbolinks:load", function() {
+    $(".timelens:empty").each(function() {
+        const t = this;
+        timelens(this, {
+            timeline: this.dataset.timeline,
+            thumbnails: this.dataset.thumbnails,
+            seek: function(position) {
+                location.href =
+                    "/v/" + t.dataset.slug + "#t=" + Math.round(position);
+            }
+        });
+    });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,3 +37,6 @@
 //= require clappr-thumbnails-plugin
 //= require clappr-playback-rate-plugin
 //= require relive-seek
+
+//= require timelens
+//= require activate-timelens

--- a/app/assets/javascripts/oembed-player.js
+++ b/app/assets/javascripts/oembed-player.js
@@ -1,3 +1,5 @@
 //= require jquery
 //= require mirrorbrain-fix
 //= require mediaelement-and-player
+
+//= require timelens

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,6 +13,8 @@
  *= require icomoon-font
  *= require jquery.bxslider
  *= require mediaelementplayer
+ *= require timelens
+ *= require timelens-custom
 
  *= require source-chooser/source-chooser
  *= require speed/speed

--- a/app/assets/stylesheets/embed.css.scss
+++ b/app/assets/stylesheets/embed.css.scss
@@ -1,6 +1,8 @@
 /*
  *= require_self
  *= require mediaelementplayer
+
+ *= require timelens
  */
 
 body {

--- a/app/assets/stylesheets/timelens-custom.css
+++ b/app/assets/stylesheets/timelens-custom.css
@@ -1,0 +1,4 @@
+.caption .timelens {
+    height: 2em;
+    cursor: pointer;
+}

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -83,7 +83,7 @@ class Api::EventsController < ApiController
   def create_event(params)
     @event.transaction do
       @event.release_date = Time.now unless @event.release_date
-      @event.set_image_filenames(params[:thumb_url], params[:poster_url])
+      @event.set_image_filenames(params[:thumb_url], params[:poster_url], params[:timeline_url], params[:thumbnails_url])
       return @event.save
     end
     false
@@ -93,7 +93,7 @@ class Api::EventsController < ApiController
     params.require(:event).permit(:guid, :slug,
       :title, :subtitle, :link,
       :original_language,
-      :thumb_filename, :poster_filename,
+      :thumb_filename, :poster_filename, :timeline_filename, :thumbnails_filename,
       :conference_id,
       :metadata,
       :description, :date,

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,6 +31,10 @@ class Event < ApplicationRecord
 
   has_attached_file :poster, via: :poster_filename, belongs_into: :images, on: :conference
 
+  has_attached_file :timeline, via: :timeline_filename, belongs_into: :images, on: :conference
+
+  has_attached_file :thumbnails, via: :thumbnails_filename, belongs_into: :images, on: :conference
+
   after_initialize :generate_guid
   before_save { trim_paths }
   after_save { conference.update_last_released_at_column if saved_change_to_release_date? }
@@ -104,9 +108,11 @@ class Event < ApplicationRecord
     recordings.maximum(:length) || 0
   end
 
-  def set_image_filenames(thumb_url, poster_url)
+  def set_image_filenames(thumb_url, poster_url, timeline_url, thumbnails_url)
     self.thumb_filename = get_image_filename thumb_url if thumb_url
     self.poster_filename = get_image_filename poster_url if poster_url
+    self.timeline_filename = get_image_filename timeline_url if timeline_url
+    self.thumbnails_filename = get_image_filename thumbnails_url if thumbnails_url
   end
 
   def display_name
@@ -181,6 +187,8 @@ class Event < ApplicationRecord
   def trim_paths
     thumb_filename.strip! unless thumb_filename.blank?
     poster_filename.strip! unless poster_filename.blank?
+    timeline_filename.strip! unless timeline_filename.blank?
+    thumbnails_filename.strip! unless thumbnails_filename.blank?
     link.strip! unless link.blank?
   end
 

--- a/app/models/frontend/event.rb
+++ b/app/models/frontend/event.rb
@@ -48,6 +48,14 @@ module Frontend
       end
     end
 
+    def timeline_url
+      File.join(Settings.static_url, conference.images_path, timeline_filename).freeze if timeline_filename
+    end
+
+    def thumbnails_url
+      File.join(Settings.static_url, conference.images_path, thumbnails_filename).freeze if thumbnails_filename
+    end
+
     def tags
       self[:tags].compact.collect(&:to_s).collect(&:strip).map!(&:freeze)
     end
@@ -144,6 +152,10 @@ module Frontend
 
     def relive
       conference.metadata['relive']&.first { |r| r['guid'] == guid }
+    end
+
+    def timelens_present?
+        timeline_filename.present? and thumbnails_filename.present?
     end
 
     private

--- a/app/views/frontend/shared/_event_metadata.haml
+++ b/app/views/frontend/shared/_event_metadata.haml
@@ -1,4 +1,7 @@
 .caption
+  - if event.timelens_present?
+    %div.timelens{data: {timeline: event.timeline_url, thumbnails: event.thumbnails_url, slug: event.slug, duration: event.duration}}
+
   %h3
     %a{href: event_path(slug: event.slug)}
       = truncate(event.title, length: 90, separator: ' ', omission: '…')

--- a/app/views/frontend/shared/_player_video.haml
+++ b/app/views/frontend/shared/_player_video.haml
@@ -1,9 +1,12 @@
-%video.video{controls: 'controls', 'data-id' => event.id, poster: event.poster_url, width: width, height: height}
+%video.video{controls: 'controls', 'data-id' => event.id, poster: event.poster_url, width: width, height: height, preload: 'auto', 'data-timeline' => (event.timelens_present? ? event.timeline_url : nil)}
   - event.videos_sorted_by_language.each do |recording|
     %source{type: recording.mime_type, src: h(recording.url), data: { lang: recording.language, quality: recording_quality(recording) }, title: recording_title(recording)}
 
   - event.recordings.subtitle.each do |track|
     %track{kind: "subtitles", src: h(track.cors_url), srclang: track.language_iso_639_1()}
+
+  - if event.timelens_present?
+    %track{kind: "metadata", label: "thumbnails", src: event.thumbnails_url, srclang: "unknown"}
 
   %link{rel: "postroll", href: postroll_path(slug: event.slug)}
 
@@ -28,13 +31,16 @@
         usePluginFullScreen: true,
         enableAutosize: true,
         stretching: '#{stretching}',
-        features: ['skipback', 'playpause', 'jumpforward', 'progress', 'current', 'duration', 'tracks', 'volume', 'speed', 'sourcechooser', 'fullscreen', 'postroll'],
+        features: ['skipback', 'playpause', 'jumpforward', 'progress', 'current', 'duration', 'tracks', 'volume', 'speed', 'sourcechooser', 'fullscreen', 'postroll', 'timelens'],
         skipBackInterval: 15,
         success: function (mediaElement) {
           mediaElement.addEventListener('canplay', function () {
             if(stamp) {
               mediaElement.setCurrentTime(stamp);
               stamp = null;
+              // Toggle play on/off so that the preview image is correct:
+              mediaElement.play();
+              mediaElement.pause();
             }
           });
           mediaElement.addEventListener('playing', function () {

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -3,6 +3,8 @@ json.length event.duration
 json.duration event.duration
 json.thumb_url event.get_thumb_url
 json.poster_url event.get_poster_url
+json.timeline_url event.get_timeline_url
+json.thumbnails_url event.get_thumbnails_url
 json.frontend_link frontend_event_url(slug: event.slug)
 json.url public_event_url(id: event.guid, format: :json)
 json.conference_url public_conference_url(id: event.conference.acronym, format: :json)

--- a/db/migrate/20180914181622_add_timelens_to_event.rb
+++ b/db/migrate/20180914181622_add_timelens_to_event.rb
@@ -1,0 +1,6 @@
+class AddTimelensToEvent < ActiveRecord::Migration[5.1]
+  def change
+    add_column :events, :timeline_filename, :string, :default => ''
+    add_column :events, :thumbnails_filename, :string, :default => ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171111211412) do
+ActiveRecord::Schema.define(version: 20180914181622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,6 +100,8 @@ ActiveRecord::Schema.define(version: 20171111211412) do
     t.integer "downloaded_recordings_count", default: 0
     t.string "original_language"
     t.jsonb "metadata", default: {}
+    t.string "timeline_filename", default: ""
+    t.string "thumbnails_filename", default: ""
     t.index ["conference_id"], name: "index_events_on_conference_id"
     t.index ["guid"], name: "index_events_on_guid"
     t.index ["metadata"], name: "index_events_on_metadata", using: :gin

--- a/test/controllers/api/events_controller_test.rb
+++ b/test/controllers/api/events_controller_test.rb
@@ -64,6 +64,8 @@ class Api::EventsControllerTest < ActionController::TestCase
       guid: 'qwerty',
       poster_url: 'http://koeln.ccc.de/images/chaosknoten_preview.jpg',
       thumb_url: 'http://koeln.ccc.de/images/chaosknoten.jpg',
+      timeline_url: 'http://koeln.ccc.de/images/chaosknoten.timeline.jpg',
+      thumbnails_url: 'http://koeln.ccc.de/images/chaosknoten.thumbnails.vtt',
       original_language: 'eng-deu',
       slug: 'best_event',
       title: 'Event?',

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -105,6 +105,8 @@ FactoryBot.define do
     title { generate(:event_title) }
     thumb_filename 'frabcon123.jpg'
     poster_filename 'frabcon123_logo.jpg'
+    timeline_filename 'frabcon123.timeline.jpg'
+    thumbnails_filename 'frabcon123.thumbnails.vtt'
     subtitle 'subtitle'
 
     original_language 'eng'

--- a/test/integration/events_api_test.rb
+++ b/test/integration/events_api_test.rb
@@ -23,7 +23,9 @@ class EventsApiTest < ActionDispatch::IntegrationTest
     json += @conference.acronym
     json += '",'
     json += '"poster_url":"http://koeln.ccc.de/images/chaosknoten_preview.jpg",'
-    json += '"thumb_url":"http://koeln.ccc.de/images/chaosknoten.jpg"'
+    json += '"thumb_url":"http://koeln.ccc.de/images/chaosknoten.jpg",'
+    json += '"timeline_url":"http://koeln.ccc.de/images/chaosknoten.timeline.jpg",'
+    json += '"thumbnails_url":"http://koeln.ccc.de/images/chaosknoten.thumbnails.vtt"'
     json+= '}'
     json
   end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -56,9 +56,11 @@ class EventTest < ActiveSupport::TestCase
   end
 
   test 'should trim whitespace on paths' do
-    event = create(:event, poster_filename: ' poster.png ', thumb_filename: ' thump.jpeg ', title: '  some  artistic   title ')
+    event = create(:event, poster_filename: ' poster.png ', thumb_filename: ' thump.jpeg ', timeline_filename: ' timeline.jpeg ', thumbnails_filename: ' thumbnails.vtt ', title: '  some  artistic   title ')
     assert_equal event.poster_filename, event.poster_filename.strip
     assert_equal event.thumb_filename, event.thumb_filename.strip
+    assert_equal event.timeline_filename, event.timeline_filename.strip
+    assert_equal event.thumbnails_filename, event.thumbnails_filename.strip
     refute_equal event.title, event.title.strip
   end
 

--- a/vendor/assets/javascripts/timelens.js
+++ b/vendor/assets/javascripts/timelens.js
@@ -1,0 +1,274 @@
+/* Common functionality */
+
+function timelens(container, options) {
+    // Load VTT file asynchronously, then continue with the initialization.
+    let vtt_url;
+    if (options.thumbnails) {
+        vtt_url = options.thumbnails;
+    }
+
+    const request = new XMLHttpRequest();
+    request.open("GET", vtt_url, true);
+    request.send(null);
+    request.onreadystatechange = function() {
+        if (request.readyState === 4 && request.status === 200) {
+            const type = request.getResponseHeader("Content-Type");
+            if (type.indexOf("text") !== 1) {
+                timelens2(container, request.responseText, options);
+            }
+        }
+    };
+}
+
+// Actually initialize Timelens.
+function timelens2(container, vtt, options) {
+    const thumbnails = parseVTT(vtt);
+    const duration = thumbnails[thumbnails.length - 1].to;
+
+    // Use querySelector if a selector string is specified.
+    if (typeof container == "string")
+        container = document.querySelector(container);
+
+    // This will be our main .timelens div, which will contain all new elements.
+    if (container.className != "") {
+        container.className += " ";
+    }
+    container.className += "timelens";
+
+    // Create div which contains the preview thumbnails.
+    const thumbnail = document.createElement("div");
+    thumbnail.className = "timelens-thumbnail";
+
+    // Create div which contains the thumbnail time.
+    const time = document.createElement("div");
+    time.className = "timelens-time";
+
+    // Create .timeline img, which displays the visual timeline.
+    const timeline = document.createElement("img");
+    timeline.src = options.timeline;
+    // Prevent the timeline image to be dragged
+    timeline.setAttribute("draggable", "false");
+
+    // Create .marker div, which is used to display the current position.
+    if (options.position) {
+        var marker = document.createElement("div");
+        marker.className = "timelens-marker-border";
+        container.appendChild(marker);
+
+        var markerInner = document.createElement("div");
+        markerInner.className = "timelens-marker";
+        marker.appendChild(markerInner);
+    }
+
+    // Assemble everything together.
+    container.appendChild(timeline);
+    container.appendChild(thumbnail);
+    thumbnail.appendChild(time);
+
+    // When clicking the timeline, seek to the respective position.
+    if (options.seek) {
+        timeline.onclick = function(event) {
+            const progress = progressAtMouse(event, timeline);
+            options.seek(progress * duration);
+        };
+    }
+
+    timeline.onmousemove = function(event) {
+        // Calculate click position in seconds.
+        const progress = progressAtMouse(event, timeline);
+        const seconds = progress * duration;
+        const x = progress * timeline.offsetWidth;
+
+        const thumbnail_dir = options.thumbnails.substring(
+            0,
+            options.thumbnails.lastIndexOf("/") + 1
+        );
+
+        // Find the first entry in `thumbnails` which contains the current position.
+        let active_thumbnail = null;
+        for (let t of thumbnails) {
+            if (seconds >= t.from && seconds <= t.to) {
+                active_thumbnail = t;
+                break;
+            }
+        }
+
+        // Set respective background image.
+        thumbnail.style["background-image"] =
+            "url(" + thumbnail_dir + active_thumbnail.file + ")";
+        // Move background to the correct location.
+        thumbnail.style["background-position"] =
+            -active_thumbnail.x + "px " + -active_thumbnail.y + "px";
+
+        // Set thumbnail div to correct size.
+        thumbnail.style.width = active_thumbnail.w + "px";
+        thumbnail.style.height = active_thumbnail.h + "px";
+
+        // Move thumbnail div to the correct position.
+        thumbnail.style.marginLeft =
+            Math.min(
+                Math.max(0, x - thumbnail.offsetWidth / 2),
+                timeline.offsetWidth - thumbnail.offsetWidth
+            ) + "px";
+
+        time.innerHTML = to_timestamp(seconds);
+    };
+
+    if (options.position) {
+        setInterval(function() {
+            marker.style.marginLeft =
+                (options.position() / duration) * timeline.offsetWidth + "px";
+        }, 1);
+    }
+}
+
+// Convert a WebVTT timestamp (which has the format [HH:]MM:SS.mmm) to seconds.
+function from_timestamp(timestamp) {
+    const matches = timestamp.match(/(.*):(.*)\.(.*)/);
+
+    const minutes = parseInt(matches[1]);
+    const seconds = parseInt(matches[2]);
+    const mseconds = parseInt(matches[3]);
+
+    const seconds_total = mseconds / 1000 + seconds + 60 * minutes;
+
+    return seconds_total;
+}
+
+// Convert a position in seconds to a [H:]MM:SS timestamp.
+function to_timestamp(seconds_total) {
+    const hours = Math.floor(seconds_total / 60 / 60);
+    const minutes = Math.floor(seconds_total / 60 - hours * 60);
+    const seconds = Math.floor(seconds_total - 60 * minutes - hours * 60 * 60);
+
+    const timestamp = minutes + ":" + pad(seconds, 2);
+
+    if (hours > 0) {
+        return hours + ":" + pad(timestamp, 5);
+    } else {
+        return timestamp;
+    }
+}
+
+// How far is the mouse into the timeline, in a range from 0 to 1?
+function progressAtMouse(event, timeline) {
+    const x = event.offsetX ? event.offsetX : event.pageX - timeline.offsetLeft;
+    return x / timeline.offsetWidth;
+}
+
+// Parse a VTT file pointing to JPEG files using media fragment notation.
+function parseVTT(vtt) {
+    let from = 0;
+    let to = 0;
+
+    let thumbnails = [];
+
+    for (let line of vtt.split("\n")) {
+        if (/-->/.test(line)) {
+            // Parse a "cue timings" part.
+            const matches = line.match(/(.*) --> (.*)/);
+
+            from = from_timestamp(matches[1]);
+            to = from_timestamp(matches[2]);
+        } else if (/jpg/.test(line)) {
+            // Parse a "cue payload" part.
+            const matches = line.match(/(.*)\?xywh=(.*),(.*),(.*),(.*)/);
+
+            thumbnails.push({
+                from: from,
+                to: to,
+                file: matches[1],
+                x: matches[2],
+                y: matches[3],
+                w: matches[4],
+                h: matches[5]
+            });
+        }
+    }
+
+    return thumbnails;
+}
+
+function pad(num, size) {
+    return ("000000000" + num).substr(-size);
+}
+
+/* MediaElement.js */
+
+if (typeof MediaElementPlayer !== "undefined") {
+    Object.assign(MediaElementPlayer.prototype, {
+        buildtimelens(player, controls, layers, media) {
+            const t = this;
+
+            // Get the timeline from the video's "timeline" attribute.
+            const vid = media.querySelector("video");
+            const timeline = vid.dataset.timeline;
+
+            // Get the thumbnails VTT from a "thumbnails" track.
+            const thumbnailsTrack = vid.querySelector(
+                'track[label="thumbnails"]'
+            );
+
+            // When there's insufficient data, don't initialize Timelens.
+            if (!timeline || !thumbnailsTrack) {
+                return;
+            }
+
+            const thumbnails = thumbnailsTrack.src;
+
+            const slider = controls.querySelector(
+                "." + t.options.classPrefix + "time-slider"
+            );
+
+            // Initialize the Timelens interface.
+            timelens(slider, {
+                timeline: timeline,
+                thumbnails: thumbnails,
+                position: function() {
+                    return player.currentTime;
+                }
+            });
+        }
+    });
+}
+
+/* Clappr */
+
+if (typeof Clappr !== "undefined") {
+    class Timelens extends Clappr.UICorePlugin {
+        get name() {
+            return "timelens";
+        }
+
+        constructor(core) {
+            super(core);
+        }
+
+        bindEvents() {
+            this.listenTo(
+                this.core.mediaControl,
+                Clappr.Events.MEDIACONTROL_RENDERED,
+                this._init
+            );
+        }
+
+        _init() {
+            const bar = this.core.mediaControl.el.querySelector(
+                ".bar-background"
+            );
+
+            let t = this;
+
+            // Initialize the Timelens interface.
+            timelens(bar, {
+                timeline: this.core.options.timelens.timeline,
+                thumbnails: this.core.options.timelens.thumbnails,
+                position: function() {
+                    return t.core.containers[0].getCurrentTime();
+                }
+            });
+        }
+    }
+
+    window.Timelens = Timelens;
+}

--- a/vendor/assets/stylesheets/timelens.css
+++ b/vendor/assets/stylesheets/timelens.css
@@ -1,0 +1,116 @@
+/* Common styles */
+
+.timelens {
+    position: relative;
+}
+
+.timelens img {
+    width: 100%;
+    height: 100%;
+    display: block;
+
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -o-user-select: none;
+    user-select: none;
+
+    position: relative;
+}
+
+.timelens-thumbnail {
+    background: black;
+    border: solid rgba(28, 28, 28, 0.9) 3px !important;
+    border-radius: 3px;
+    background-clip: content-box;
+    width: 0px;
+    height: 0px;
+    position: absolute;
+    top: 0;
+    z-index: -1;
+    opacity: 0;
+    transition: opacity 0.2s, z-index 0.2s;
+    transform: translateY(-100%) translateY(-7px);
+}
+
+.timelens-time {
+    font-size: 15px !important;
+    font-family: Arial, sans-serif !important;
+    color: #eee;
+    background: rgba(28, 28, 28, 0.9);
+    position: absolute;
+    left: 50%;
+    bottom: 0;
+    transform: translateX(-50%);
+    display: inline-block !important;
+    padding: 0 10px !important;
+    border-radius: 2px 2px 0 0;
+    height: 22px;
+    vertical-align: middle !important;
+    line-height: 25px !important;
+}
+
+.timelens img:hover + .timelens-thumbnail {
+    z-index: 999;
+    opacity: 1;
+}
+
+.timelens-marker {
+    width: 0px;
+    height: 0px;
+    border-top: 15px solid #eee !important;
+    border-left: 10px solid transparent !important;
+    border-right: 10px solid transparent !important;
+    position: absolute;
+    top: -20px;
+    z-index: 999;
+    transform: translateX(-50%);
+}
+
+.timelens-marker-border {
+    width: 0px;
+    height: 0px;
+    border-top: 23px solid rgba(28, 28, 28, 0.9) !important;
+    border-left: 15px solid transparent !important;
+    border-right: 15px solid transparent !important;
+    position: absolute;
+    top: -10px;
+    z-index: 999;
+    transform: translateX(-50%);
+}
+
+/* MediaElement.js */
+
+.mejs__time-slider.timelens {
+    height: 40px;
+    margin-top: -10px;
+    box-shadow: 0 0 0 2px #eee, 0 0 40px 2px rgba(0, 0, 0, 0.35);
+    border-radius: 0;
+}
+
+.timelens .mejs__time-buffering,
+.timelens .mejs__time-loaded,
+.timelens .mejs__time-current,
+.timelens .mejs__time-hovered,
+.timelens .mejs__time-handle,
+.timelens .mejs__time-float {
+    display: none !important;
+}
+
+/* Clappr */
+
+.media-control .bar-background {
+    height: 40px !important;
+    margin-top: -40px;
+    box-shadow: 0 0 0 2px #eee;
+}
+
+.media-control .seek-time,
+.media-control .bar-scrubber,
+.media-control .bar-hover {
+    display: none !important;
+}
+
+.media-control-hide {
+    bottom: -40px !important;
+}


### PR DESCRIPTION
This adds support for displaying visual timelines and popup thumbnails
throughout voctoweb's interface, aiming to make video navigation more
efficient, precise, and active. See <https://timelens.io> for an explanation of
what this is all about.

Two fields, "timeline_filename" and "thumbnails_filename" are added to
the Event model. When present, the Timelens plugin for MediaElement.js
is activated. Also, Timelens interfaces are added to video listings.

When the Timelens fields are not filled, everything works as before.