### PR TITLE
Support slides subdirectories

### DIFF
--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -19,8 +19,8 @@ class Recording < ApplicationRecord
 
   scope :video, -> { where(mime_type: MimeType::VIDEO) }
   scope :audio, -> { where(mime_type: MimeType::AUDIO) }
-  scope :slides, -> { where("folder LIKE 'slides%'") }
-  scope :video_without_slides, -> { video.where("folder NOT LIKE 'slides%'") }
+  scope :slides, -> { where("folder LIKE '%slides%'") }
+  scope :video_without_slides, -> { video.where("folder NOT LIKE '%slides%'") }
   scope :subtitle, -> { where(mime_type: MimeType::SUBTITLE) }
   scope :html5, -> { where(html5: true) }
   scope :original_language, -> { joins(:event).where('events.original_language = recordings.language') }


### PR DESCRIPTION
Some contributors use subdirectories named by year for their uploads; with those slides weren't correctly detected as the directory name didn't start with `slides` but rather with e.g. `2018/slides`. This patch changes the behavior so that the string `slides` can be anywhere in the path and doesn't need to be at the beginning.