### PR TITLE
remove hint files will be served over http

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -46,7 +46,6 @@
 
   %p
     Video and audio files are often provided by mirrors and are not covered by this policy.
-    These files are served via HTTP, without encryption, due to technical issues.
 
   %h2 Current Mirrors
 


### PR DESCRIPTION
all mirrors of [https://media.ccc.de/about.html#status](https://media.ccc.de/about.html#status) serve files over https, so the hint can be removed.