### PR TITLE
Repurpose timelens as lower separator

### DIFF
--- a/app/views/frontend/shared/_event_metadata.haml
+++ b/app/views/frontend/shared/_event_metadata.haml
@@ -1,7 +1,4 @@
 .caption
-  - if event.timelens_present?
-    %div.timelens{data: {timeline: event.timeline_url, thumbnails: event.thumbnails_url, slug: event.slug, duration: event.duration}}
-
   %h3
     %a{href: event_path(slug: event.slug)}
       = truncate(event.title, length: 90, separator: ' ', omission: '…')
@@ -22,3 +19,6 @@
       = event.view_count
     %li.persons
       = render partial: 'frontend/shared/event_persons', locals: { persons: event.persons }
+
+- if event.timelens_present?
+    %div.timelens{data: {timeline: event.timeline_url, thumbnails: event.thumbnails_url, slug: event.slug, duration: event.duration}}


### PR DESCRIPTION
Because there are (still) many media items that have no timelens, search results may show a mixture of items with the title up top and items with the title pushed down. I suggest that the search result page will look more consistent with the timelens below the other metadata.

What do you think?