### PR TITLE
correctly match event to relive recording

### DIFF
--- a/app/models/frontend/event.rb
+++ b/app/models/frontend/event.rb
@@ -151,7 +151,7 @@ module Frontend
     end
 
     def relive
-      conference.metadata['relive']&.first { |r| r['guid'] == guid }
+      conference.metadata['relive']&.find { |r| r['guid'] == guid }
     end
 
     def timelens_present?


### PR DESCRIPTION
#first does not accept a block, which results in this function always
returning the first relive recording, rather than a matching one. Use
#find instead.