### PR TITLE
Improve timelens alignment

### DIFF
--- a/app/assets/stylesheets/frontend/shared/_eventpreview_meta.scss
+++ b/app/assets/stylesheets/frontend/shared/_eventpreview_meta.scss
@@ -4,7 +4,7 @@
   .metadata {
     text-align: left;
     border: none;
-    position: absolute;
+    position: relative;
     bottom: 0;
     margin-bottom: 0;
     padding: 5px 0 8px 0;

--- a/app/assets/stylesheets/timelens-custom.css
+++ b/app/assets/stylesheets/timelens-custom.css
@@ -1,4 +1,4 @@
 .caption .timelens {
-    height: 2em;
+    height: 1.4em;
     cursor: pointer;
 }

--- a/app/views/frontend/shared/_event_metadata.haml
+++ b/app/views/frontend/shared/_event_metadata.haml
@@ -1,7 +1,7 @@
 .caption
   %h3
     %a{href: event_path(slug: event.slug)}
-      = truncate(event.title, length: 90, separator: ' ', omission: '…')
+      = truncate(event.title, length: 75, separator: ' ', omission: '…')
 
   - if event.subtitle.present?
     %h4{title: event.subtitle}


### PR DESCRIPTION
Follow-up to #349, because that one didn't contain any CSS update which may be desired for nicer timelens display:

![screen shot 2019-01-02 at 11 25 32](https://user-images.githubusercontent.com/9948149/50588172-2b356380-0e81-11e9-84a9-600cc44c3d75.png)

In case an event has no subtitle, the timelens is still shifted towards the middle of the thumbnail:

![screen shot 2019-01-02 at 11 23 50](https://user-images.githubusercontent.com/9948149/50588116-ead5e580-0e80-11e9-8750-2df19432b91f.png)

I couldn't figure this out during 1h of playing around with various `align`, `position`, `bottom` and `margin` style settings. Hoping these suggestions are still helpful iterations on the way. Please feel free to update them directly in this PR.