### PR TITLE
Public API: Speed improvements

### DIFF
--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -21,7 +21,7 @@ class Public::EventsController < ActionController::Base
         .where(guid: params[:id])
         .or(Event.where(slug: params[:id]))
         .includes(recordings: :conference)
-        .first
+        .take
     end
 
     fail ActiveRecord::RecordNotFound unless @event

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -4,7 +4,7 @@ class Public::EventsController < ActionController::Base
   respond_to :json
 
   def index
-    @events = paginate(Event.all, per_page: 50, max_per_page: 256)
+    @events = paginate(Event.all.includes(:conference), per_page: 50, max_per_page: 256)
   end
 
   # GET /public/events/1
@@ -13,10 +13,17 @@ class Public::EventsController < ActionController::Base
   # GET /public/events/654331ae-1710-42e5-bdf4-65a03a80c614.json
   def show
     if params[:id] =~ /\A[0-9]+\z/
-      @event = Event.find(params[:id])
+      @event = Event
+        .includes(recordings: :conference)
+        .find(params[:id])
     else
-      @event = Event.find_by(guid: params[:id])
+      @event = Event
+        .where(guid: params[:id])
+        .or(Event.where(slug: params[:id]))
+        .includes(recordings: :conference)
+        .first
     end
+
     fail ActiveRecord::RecordNotFound unless @event
   end
 

--- a/app/controllers/public/recordings_controller.rb
+++ b/app/controllers/public/recordings_controller.rb
@@ -5,7 +5,7 @@ class Public::RecordingsController < ActionController::Base
   respond_to :json
 
   def index
-    @recordings = paginate(Recording.all, per_page: 50, max_per_page: 256)
+    @recordings = paginate(Recording.all.includes(:event, :conference), per_page: 50, max_per_page: 256)
   end
 
   # GET /public/recordings/1.json

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -134,6 +134,13 @@ class Event < ApplicationRecord
     end
   end
 
+  def related_events
+    unless self.metadata['related'].nil?
+      ids = self.metadata['related'].keys
+      Event.find(ids)
+    end
+  end
+
   # for elastic search
   def remote_id
     metadata['remote_id']

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -136,8 +136,8 @@ class Event < ApplicationRecord
   end
 
   def related_events
-    unless self.metadata['related'].nil?
-      ids = self.metadata['related'].keys
+    unless metadata['related'].nil?
+      ids = metadata['related'].keys
       Event.find(ids)
     end
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,12 +18,13 @@ class Event < ApplicationRecord
   serialize :persons, Array
   serialize :tags, Array
 
-  # events with recordings of any type for a given conference
+  # get all Events of a Conference with at least one Recording
   scope :recorded_at, ->(conference) {
-    joins(:recordings, :conference)
-      .where(conferences: { id: conference })
-      .where(recordings: { mime_type: MimeType.all })
-      .group(:id)
+    # reuse conference so using event.conference does not trigger a query
+    conference
+      .events
+      .includes(:recordings)
+      .where.not(recordings: { id: nil })
   }
   scope :recent, ->(n) { order('release_date desc').limit(n) }
 

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -8,8 +8,8 @@ json.thumbnails_url event.get_thumbnails_url
 json.frontend_link frontend_event_url(slug: event.slug)
 json.url public_event_url(id: event.guid, format: :json)
 json.conference_url public_conference_url(id: event.conference.acronym, format: :json)
-json.related(event.metadata['related']) do |id, weight|
-  json.event_id id
-  json.event_guid Event.find(id)&.guid
-  json.weight weight
+json.related(event.related_events) do |related_event|
+  json.event_id related_event.id
+  json.event_guid related_event.guid
+  json.weight event.metadata['related'][related_event.id.to_s]
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -163,4 +163,12 @@ class EventTest < ActiveSupport::TestCase
     @event.update(release_date: release_date)
     assert_equal release_date, @event.conference.event_last_released_at
   end
+
+  test 'should resolve related_events from metadata' do
+    e = create(:event)
+    e.metadata = {'related': Hash[@event.id, 1] }
+    e.save!
+
+    assert_includes e.related_events, @event
+  end
 end


### PR DESCRIPTION
This pull request should greatly reduce the amount of SQL queries needed for requests to the public API. It does not change API response behavior.

Furthermore, it adds the capability to request events by their slug, e.g. `/public/events/dg-82` now returns the same information as `/public/events/70d63b5d-0e39-4271-b4e5-fefc783b2a2b`.