### PR TITLE
Public API: Fix pagination

### DIFF
--- a/app/controllers/public/conferences_controller.rb
+++ b/app/controllers/public/conferences_controller.rb
@@ -1,8 +1,17 @@
 module Public
   class ConferencesController < InheritedResources::Base
     include ApiErrorResponses
+    include Rails::Pagination
     respond_to :json
-    actions :index
+
+    def index
+      # stay backwards-compatible
+      if params[:page] or params[:per_page]
+        @conferences = paginate Conference.all
+      else
+        @conferences = Conference.all
+      end
+    end
 
     # GET /public/conferences/54
     # GET /public/conferences/54.json

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -4,7 +4,7 @@ class Public::EventsController < ActionController::Base
   respond_to :json
 
   def index
-    @events = paginate(Event.all.includes(:conference), per_page: 50, max_per_page: 256)
+    @events = paginate Event.all.includes(:conference)
   end
 
   # GET /public/events/1
@@ -28,10 +28,9 @@ class Public::EventsController < ActionController::Base
   end
 
   def search
-    results = Frontend::Event.query(params[:q]).page(params[:page])
-    # calling this just to set headers
-    paginate(results)
-    @events = results.records.includes(recordings: :conference)
-    respond_to { |format| format.json }
+    @events = paginate Frontend::Event
+      .query(params[:q])
+      .records
+      .includes(recordings: :conference)
   end
 end

--- a/app/controllers/public/recordings_controller.rb
+++ b/app/controllers/public/recordings_controller.rb
@@ -5,7 +5,7 @@ class Public::RecordingsController < ActionController::Base
   respond_to :json
 
   def index
-    @recordings = paginate(Recording.all.includes(:event, :conference), per_page: 50, max_per_page: 256)
+    @recordings = paginate Recording.all.includes(:event, :conference)
   end
 
   # GET /public/recordings/1.json

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 50
+  config.max_per_page = 256
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
By default, the api-pagination gem makes it possible to specify the
amount of items per page using the `per_page` query parameter. However,
when a fixed `per_page` value is set during the `paginate`-call, the
parameter is not recognized.

This commit fixes that by specifying a global, default per_page value to
Kaminari and removing local definitions. Possible implication might be a
change of the amount of displayed items in the frontend.

In addition it implements pagination on Public::ConferencesController#index
As this would be a breaking API change, the pagination is only turned on
if either the `page` or `per_page` query parameter is set.