### PR TITLE
fix GPG keys for RVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,10 @@ sudo apt-get install redis-server libpqxx-dev
 sudo apt-get install nodejs
 
 # install rvm
-gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 \curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer
 \curl -O https://raw.githubusercontent.com/rvm/rvm/master/binscripts/rvm-installer.asc
-gpg --verify rvm-installer.asc
+gpg --verify rvm-installer.asc rvm-installer
 bash rvm-installer stable
 source ~/.rvm/scripts/rvm
 


### PR DESCRIPTION
The RVM people have added a new person that signs their binaries, and the verify line was missing the binary on the command line.