### PR TITLE
player: fix timelens VTT parsing

### DIFF
--- a/vendor/assets/javascripts/timelens.js
+++ b/vendor/assets/javascripts/timelens.js
@@ -124,13 +124,23 @@ function timelens2(container, vtt, options) {
 
 // Convert a WebVTT timestamp (which has the format [HH:]MM:SS.mmm) to seconds.
 function from_timestamp(timestamp) {
-    const matches = timestamp.match(/(.*):(.*)\.(.*)/);
+    var matches = timestamp.match(/(.*):(.*):(.*)\.(.*)/);
+    if (matches === null)
+        matches = timestamp.match(/(.*):(.*)\.(.*)/);
 
-    const minutes = parseInt(matches[1]);
-    const seconds = parseInt(matches[2]);
-    const mseconds = parseInt(matches[3]);
+    if (matches.length == 5) {
+        var hours = parseInt(matches[1]);
+        var minutes = parseInt(matches[2]);
+        var seconds = parseInt(matches[3]);
+        var mseconds = parseInt(matches[4]);
+    } else {
+        var hours = 0;
+        var minutes = parseInt(matches[1]);
+        var seconds = parseInt(matches[2]);
+        var mseconds = parseInt(matches[3]);
+    }
 
-    const seconds_total = mseconds / 1000 + seconds + 60 * minutes;
+    const seconds_total = mseconds / 1000 + seconds + 60 * minutes + 3600 * hours;
 
     return seconds_total;
 }


### PR DESCRIPTION
The current timelens version generates VTT files with timestamps that
have an hour position instead of using minute values > 60. The version
of timelens.js used in voctoweb does not handle this, causing the
thumbnails of the first minutes to stretch over the entire video.

Fix this by importing the patch proposed in an upstream PR[1].

[1] https://github.com/timelens/timelens.js/pull/3