### PR TITLE
Fix sidekiq docker image build failing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /voctoweb
 
 # Install required gems
 COPY Gemfile Gemfile.lock /voctoweb/
-RUN gem update --system && gem install bundler && bundle install
+RUN gem update --system && gem install bundler:1.17.3 && bundle install


### PR DESCRIPTION
Building the sidekiq docker image fails because it installs bundler v>=2 but the Gemfile.lock uses v.1.17.3 which causes running bundler to fail. By pinning the version of bundler being installed this is circumvented. However somebody should probably look into upgrading to bundler 2 and the possibly breaking changes.