### PR TITLE
Improve search

### DIFF
--- a/app/controllers/frontend/search_controller.rb
+++ b/app/controllers/frontend/search_controller.rb
@@ -3,7 +3,7 @@ module Frontend
     def index
       @searchtype = ''
       @searchquery = params[:q] || params[:p]
-      if params[:q] 
+      if params[:q]
         @events = Frontend::Event.query(params[:q]).page(params[:page]).records
       else
         @searchtype = 'person'

--- a/app/models/concerns/elasticsearch_event.rb
+++ b/app/models/concerns/elasticsearch_event.rb
@@ -12,12 +12,12 @@ module ElasticsearchEvent
 
     def as_indexed_json(_options = {})
       as_json(
-        only: %i[title subtitle description persons length release_date date updated_at slug],
+        only: %i[title subtitle description persons length release_date date updated_at slug original_language translations],
         methods: :remote_id,
         id: :guid,
         include: { 
           conference: { only: %i[title acronym] },
-          subtitles: { only: %i[language], methods: :fulltext } 
+          subtitles: { only: %i[language], methods: :fulltext }
         }
       )
     end

--- a/app/models/concerns/elasticsearch_event.rb
+++ b/app/models/concerns/elasticsearch_event.rb
@@ -12,10 +12,14 @@ module ElasticsearchEvent
 
     def as_indexed_json(_options = {})
       as_json(
-        only: %i(title subtitle description persons length release_date date updated_at slug),
+        only: %i[title subtitle description persons length release_date date updated_at slug],
+        methods: :remote_id,
         id: :guid,
-        include: { conference: { only: %i(title acronym) }
-      })
+        include: { 
+          conference: { only: %i[title acronym] },
+          subtitles: { only: %i[language], methods: :fulltext } 
+        }
+      )
     end
   end
 
@@ -54,13 +58,14 @@ module ElasticsearchEvent
                     query:  term,
                     fields:  [
                       'title^20',
-                      'subtitle^3',
-                      'persons^4',
-                      'slug^2',
-                      'remote_id^2',
-                      'conference.acronym^2',
-                      'conference.title^2',
-                      'description^1'
+                      'subtitle^4',
+                      'persons^5',
+                      'slug^3',
+                      'remote_id^3',
+                      'conference.acronym^3',
+                      'conference.title^3',
+                      'description^2',
+                      'subtitles.fulltext^1'
                     ],
                     type:  'best_fields',
                     operator:  'and',

--- a/app/models/concerns/elasticsearch_event.rb
+++ b/app/models/concerns/elasticsearch_event.rb
@@ -30,7 +30,6 @@ module ElasticsearchEvent
         function_score:  {
           query:  {
             bool:  {
-              disable_coord:  true,
               should:  [
                 {
                   multi_match: {
@@ -90,7 +89,6 @@ module ElasticsearchEvent
         function_score:  {
           query:  {
             bool:  {
-              disable_coord:  true,
               should:  [
                 {
                   multi_match:  {

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -94,6 +94,10 @@ class Conference < ApplicationRecord
     update_column :downloaded_events_count, Event.recorded_at(self).to_a.size
   end
 
+  def recordings_url
+    File.join(Settings.cdn_url, recordings_path).freeze
+  end
+
   private
 
   def logo_exists?

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -175,6 +175,11 @@ class Event < ApplicationRecord
     recordings.video.sort_by { |x| (x.language == original_language ? 0 : 2) + (x.html5 ? 0 : 1) }
   end
 
+  # for elastic search
+  def subtitles
+    recordings.subtitle
+  end
+
   def doi_url
     if doi
       "https://doi.org/#{doi}"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -181,10 +181,19 @@ class Event < ApplicationRecord
   end
 
   def doi_url
-    if doi
-      "https://doi.org/#{doi}"
-    end
+    "https://doi.org/#{doi}" if doi
   end
+
+  def video_master
+    recordings.video_without_slides
+              .select { |x| x.filetype == 'video/mp4' && x.high_quality == true }
+              .min_by { |x| x.html5 ? 1 : 0 }
+  end
+
+  def translations
+    video_master.languages - [ original_language ]
+  end
+
 
   def update_feeds
     return unless release_date

--- a/app/models/frontend/conference.rb
+++ b/app/models/frontend/conference.rb
@@ -52,10 +52,6 @@ module Frontend
       }
     end
 
-    def recordings_url
-      File.join(Settings.cdn_url, recordings_path).freeze
-    end
-
     def playlist(event = nil)
       return events.includes(:conference) unless event
       n = events.index(event)

--- a/app/models/frontend/recording.rb
+++ b/app/models/frontend/recording.rb
@@ -3,14 +3,6 @@ module Frontend
     belongs_to :event, class_name: 'Frontend::Event'
     scope :by_mime_type, ->(mime_type) { where(mime_type: mime_type) }
 
-    def url
-      File.join(event.conference.recordings_url, folder || '', filename).freeze
-    end
-
-    def cors_url
-      File.join(Settings.cors_url, event.conference.recordings_path, folder || '', filename).freeze
-    end
-
     def resolution
       return '' unless height
       if height < 720

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -142,6 +142,7 @@ class Recording < ApplicationRecord
     begin 
       URI.open(url).read if subtitle?
     rescue OpenURI::HTTPError
+      puts '   failed with HTTP Error'
       ''
     end
   end

--- a/app/models/recording.rb
+++ b/app/models/recording.rb
@@ -128,6 +128,24 @@ class Recording < ApplicationRecord
     language.split('-')
   end
 
+  def url
+    File.join(event.conference.recordings_url, folder || '', filename).freeze
+  end
+
+  def cors_url
+    File.join(Settings.cors_url, event.conference.recordings_path, folder || '', filename).freeze
+  end
+
+  # for elastic search
+  def fulltext
+    puts ' downloading ' + url
+    begin 
+      URI.open(url).read if subtitle?
+    rescue OpenURI::HTTPError
+      ''
+    end
+  end
+
   private
 
   def language_valid

--- a/app/views/frontend/search/index.html.haml
+++ b/app/views/frontend/search/index.html.haml
@@ -16,6 +16,8 @@
     .event-previews
       - @events.each do |event|
         = render partial: 'frontend/shared/event_with_conference', locals: { event: event }
+    = link_to_prev_page @events, 'prev'
+    = link_to_next_page @events, 'next'
   - else
     %p
       The Search for "#{@searchquery}" did not return any results.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,12 +36,32 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
   elasticsearch:
-    image: elasticsearch:5-alpine
+    image: elasticsearch:6.8.6
     ports:
       - "9200:9200"
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - http.cors.enabled=true
+      - http.cors.allow-origin=*
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     volumes:
 #      - esdata:/usr/share/elasticsearch/data
       - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+  # kibana:
+  #   image: 'docker.elastic.co/kibana/kibana:6.8.6'
+  #   container_name: kibana
+  #   environment:
+  #     SERVER_NAME: kibana.local
+  #     ELASTICSEARCH_URL: http://elasticsearch:9200
+  #   ports:
+  #     - '5601:5601'
+  #   depends_on:
+  #     - elasticsearch
   redis:
     image: redis:5-alpine
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
     image: elasticsearch:5-alpine
     ports:
       - "9200:9200"
+    volumes:
+#      - esdata:/usr/share/elasticsearch/data
+      - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   redis:
     image: redis:5-alpine
     ports:

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -1,0 +1,5 @@
+http.host: 0.0.0.0
+
+# for http://splainer.io/
+http.cors.allow-origin: "/https?:\\/\\/(.*?\\.)?(quepid\\.com|splainer\\.io)/"
+http.cors.enabled: true


### PR DESCRIPTION
This PR fixes some issues with the search query and prepares the index for the requirements outlined in #444 and #289 

* full match on titles are now weighted higher, and weighted average instead of multiply in decay function is used, so searches for the exact title of a talk e.g. "we lost the war" always yield the hopefully correct results.

For the long term we also should add some "post-integration" tests for the full content elastic index, so we can actually compare changes to the es query – @robinkaranu said he will look into that in the next weeks...