### PR TITLE
Switch docker setup to alpine + some housekeeping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Use the the official Ruby image as a base
-FROM ruby:2.6.0
+FROM ruby:2.6-alpine
 
 # Install runtime dependencies
 # Node.js is used for JavaScript compression via the uglifier gem
-RUN apt-get update -qq && apt-get install -y nodejs dumb-init
+RUN apk add --no-cache nodejs dumb-init curl git build-base libxml2-dev libxslt-dev postgresql-dev tzdata
 
 WORKDIR /voctoweb
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,13 @@ services:
     image: redis:5-alpine
     ports:
       - "6379:6379"
+  ssh-server:
+      image: panubo/sshd
+      volumes:
+        - ".:/voctoweb"
+        - "./docker/ssh:/root/.ssh"
+      ports:
+        - "2202:22"
   nginx:
     image: nginx:stable-alpine
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: "2"
+version: "3"
 services:
   voctoweb:
     build: .
     command: dumb-init bundle exec rails s -p 3000 -b '0.0.0.0'
     volumes:
-      - .:/voctoweb
+      - ".:/voctoweb"
       - "./docker/database.yml:/voctoweb/config/database.yml"
       - "./docker/settings.yml:/voctoweb/config/settings.yml"
     ports:
@@ -17,7 +17,6 @@ services:
       - postgres
       - elasticsearch
       - redis
-      - ssh-server
   sidekiq:
     build: .
     command: dumb-init bundle exec sidekiq
@@ -31,31 +30,25 @@ services:
       - postgres
       - redis
   postgres:
-    image: postgres:alpine
+    image: postgres:12-alpine
     volumes:
-      - "./docker/db:/var/lib/postgresql/data:rw"
+      - "./docker/db:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_PASSWORD=postgres
   elasticsearch:
     image: elasticsearch:5-alpine
     ports:
       - "9200:9200"
   redis:
-    image: redis:alpine
+    image: redis:5-alpine
     ports:
       - "6379:6379"
-  ssh-server:
-    image: panubo/sshd
-    volumes:
-      - ".:/voctoweb"
-      - "./docker/ssh:/root/.ssh"
-    ports:
-      - "2202:22"
   nginx:
-    image: nginx
+    image: nginx:stable-alpine
     volumes:
-      - ./docker/nginx.conf:/etc/nginx/conf.d/default.conf
-      - ./docker/content:/usr/share/nginx/html:ro
+      - "./docker/nginx.conf:/etc/nginx/conf.d/default.conf"
+      - "./docker/content:/usr/share/nginx/html:ro"
     ports:
       - "80:80"
-    command: /bin/bash -c "exec nginx -g 'daemon off;'"
     depends_on:
       - voctoweb

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: utf8
   username: postgres
-  password:
+  password: postgres
   host: postgres
 
 development:


### PR DESCRIPTION
The alpine switch should significantly reduce the size of to-be-downloaded container images, thus make it easier to set up the development environment.

I am not sure about the use-case of an SSH server within the development setup, thus I removed it. Shouldn't it be sufficient to just use `docker-compose run`?

Additional changes:
+ Bump docker-compose file version to 3
+ The official postgres docker image now requires a password to be set
+ Set fixed version numbers for docker containers to prevent incompatibilities
+ Some reformatting and simplification