### PR TITLE
Add subpages to 'Events' to filter by year

### DIFF
--- a/app/controllers/frontend/popular_controller.rb
+++ b/app/controllers/frontend/popular_controller.rb
@@ -1,7 +1,27 @@
 module Frontend
   class PopularController < FrontendController
+    PAGE_SIZE = 20
+
     def index
-      @events = Frontend::Event.order('view_count DESC').limit(20).includes(:conference)
+      @year = params[:year].to_i.to_s
+      @page = params[:page].to_i || 0
+      @firstyear = Frontend::Event
+        .select('date_part(\'year\',min(date)) as firstyear, -1 AS guid')
+        .take['firstyear'].to_i
+      if @year == "0"
+        @events = Frontend::Event
+          .order('view_count DESC')
+          .limit(PAGE_SIZE)
+          .offset(@page * PAGE_SIZE)
+          .includes(:conference)
+      else
+        @events = Frontend::Event
+          .where('date_part(\'year\', date) = ?', @year )
+          .order('view_count DESC')
+          .limit(PAGE_SIZE)
+          .offset(@page * PAGE_SIZE)
+          .includes(:conference)
+      end
 
       respond_to { |format| format.html }
     end

--- a/app/views/frontend/popular/index.haml
+++ b/app/views/frontend/popular/index.haml
@@ -6,7 +6,18 @@
 
 .container-fluid
   %h1 Popular Events
+  -if @year == "0"
+    %b All
+  - else
+    %a{:href => popular_path} All
+  - for year in @firstyear..Time.new.year
+    %span -
+    - if @year.to_i != year
+      %a{:href => popular_path + "/#{year}"} #{year}
+    - else
+      %b #{year}
   - if @events.present?
     .event-previews
       - @events.each do |event|
         = render partial: 'frontend/shared/event_with_conference', locals: { event: event }
+  %a{:href => "?page=" + "#{@page + 1}" } next

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
 
     get '/recent', to: 'recent#index'
     get '/popular', to: 'popular#index'
+    get '/popular/:year', to: 'popular#index'
 
     get '/tags/:tag', to: 'tags#show', as: :tag
 


### PR DESCRIPTION
This commit enhances the "Popular Events" page in two ways:
- Allow to limit the shown events by year of the event  #388
- Allow to browse through multiple pages #336 
This should also solve #207.

![Bildschirmfoto zu 2020-04-25 00-52-57](https://user-images.githubusercontent.com/509205/80262900-2bb5c700-868f-11ea-889b-a394fc8622e0.png)

![Bildschirmfoto zu 2020-04-25 00-54-33](https://user-images.githubusercontent.com/509205/80262951-5d2e9280-868f-11ea-9047-bedd901f4871.png)


Since this is the first time I commit to a ruby-on-rails project I don't expect the PR to be finished already, but would like to get some feedback, including:
- Are we nerdy enough to start counting the pages at zero or should I switch to "fortran style"?
- How bad are my SQL Queries?
- Is the "design" sophisticated enough?
- What else needs to be fixed to get this merged and deployed?