### PR TITLE
Undo Timelens styles for Clappr players inside of relive-player classes.

### DIFF
--- a/app/assets/stylesheets/timelens-custom.css
+++ b/app/assets/stylesheets/timelens-custom.css
@@ -2,3 +2,24 @@
     height: 2em;
     cursor: pointer;
 }
+
+/* Undo Timelens styles from timelens.css for Clappr players inside of relive-player classes.
+ *
+ * To avoid this, we would need to set it up in a way so that timelens.css is only loaded for pages
+ * with a Clappr player where a visual timeline is desired. */
+
+.relive-player .media-control .bar-background {
+    height: 1px !important;
+    margin-top: 0 !important;
+    box-shadow: none !important;
+}
+
+.relive-player .media-control .seek-time,
+.relive-player .media-control .bar-scrubber,
+.relive-player .media-control .bar-hover {
+    display: block !important;
+}
+
+.relive-player .media-control-hide {
+    bottom: 0 !important;
+}


### PR DESCRIPTION
The problem was that Timelens' CSS changes on the Clappr player are always applied, even if the Clappr player is used to display relive content.

This is a fast fix for the problem. I described how to solve this in a more general way in the place where the fix is applied: We would need to set it up in a way so that timelens.css is only loaded for pages with a Clappr player where a visual timeline is desired.

Fixes #420 :herb: