### PR TITLE
Update youtube-dl URL in app/views/frontend/home/about.haml

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -77,7 +77,7 @@
         [AppleTV app](https://github.com/ccc-ffm/CCC-TV). Not all talks available due to Apple Inc. a employee's interpretation of their [app store review guidelines](https://developer.apple.com/app-store/review/guidelines/)
     %li
       :markdown
-        [youtube-dl](https://github.com/rg3/youtube-dl) [module](https://github.com/rg3/youtube-dl/blob/master/youtube_dl/extractor/ccc.py)
+        [youtube-dl](https://github.com/ytdl-org/youtube-dl) [module](https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/extractor/ccc.py)
     %li
       :markdown
         [Dreambox plugin](https://github.com/opendreambox/enigma2-plugins/tree/master/c3vocupdater). Plugin for Dreambox set-top-boxes, distributed via packages Feed by Dream, Newnigma2 and Merlin4. [German blog post](https://www.dreambox-blog.com/index.php/9347/c3voc-updater-live-streams-vom-chaos-computer-club-fuer-die-dreambox)


### PR DESCRIPTION
The namespace of the youtube-dl GitHub repo has been changed.