### PR TITLE
Switch Kodi URL to GitHub repository

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -83,7 +83,7 @@
 
   :markdown
     - [youtube-dl](https://github.com/ytdl-org/youtube-dl) [module](https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/extractor/ccc.py)
-    - [Kodi addon](https://kodi.tv/addons/matrix/plugin.video.media-ccc-de)
+    - [Kodi addon](https://github.com/voc/plugin.video.media-ccc-de#mediacccde-for-kodi)
     - [Plex plugin](https://github.com/cccc/MediaCCC.bundle) (not released yet)
     - [Android TV App](https://github.com/stefanmedack/cccTV). Runs on Android TV and Fire TV. Tablet support in progress.
     - [Chaosflix](https://github.com/NiciDieNase/chaosflix). App for Android, Android TV and Fire TV.


### PR DESCRIPTION
The addon URL changed and is now different for different Kodi versions, so It's probably better to just link the GitHub repository...