### PR TITLE
add curl to make update-data not break

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ ENV BUNDLE_WITHOUT "development:test:doc"
 ENV MAKEFLAGS "-j$(nproc)"
 COPY Gemfile Gemfile.lock /voctoweb/
 RUN set -eux; \
+	apk add curl; \
 	apk add --no-cache --virtual .build-deps \
 		g++ \
 		git \


### PR DESCRIPTION
bin/update-data curls the fixtures tgz. if curl is not present in the container, it fails. 