### PR TITLE
Invert order of title components

### DIFF
--- a/app/views/layouts/frontend/frontend.html.haml
+++ b/app/views/layouts/frontend/frontend.html.haml
@@ -3,11 +3,11 @@
   %head
     = render 'frontend/shared/header'
     %title
-      = t('custom.title')
       - if content_for?(:title)
         = yield :title
       - else
         = @event.try(:title) || @conference.try(:title)
+      = t('custom.title')
 
     = yield :head
 

--- a/config/locales/custom.en.yml
+++ b/config/locales/custom.en.yml
@@ -1,6 +1,6 @@
 en:
   custom:
-    title: media.ccc.de -
+    title: '- media.ccc.de'
     news_title: media.ccc.de - NEWS
     rss:
       title:


### PR DESCRIPTION
This PR inverts the order of the components in the page title. Currently, the page title always begins with the static part `media.ccc.de` and then shows the dynamic part, i.e. the selected conference/event. This PR puts the dynamic part first and the static part second.

Fixes #723 