### PR TITLE
Specify uglifier as symbol instead

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.17.0'
+lock '3.17.1'
 
 set :application, 'media-site'
 set :repo_url, ENV['CAP_REPO']

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,10 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true, compress: { keep_fnames: true }) if defined? Uglifier
+  config.assets.configure do |env|
+    env.js_compressor  = :uglifier # or :closure, :yui
+    env.css_compressor = :sass   # or :yui
+  end
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
Failed to deploy on production with:

Uglifier::Error:
../gems/uglifier-4.2.0/lib/uglifier.rb:291:in `parse_result'

See lautis/uglifier/issues/185