### PR TITLE
Update hackint webchat URL

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -41,7 +41,7 @@
       %a{href: 'mailto:voc@c3voc.de'} voc@c3voc.de
     %li 
       %a{href: 'irc://irc.hackint.org:9999/#voc-lounge'} #voc-lounge
-      %a{href: 'https://webirc.hackint.org/#ircs://irc.hackint.org/#voc-lounge'} [Web-IRC]
+      %a{href: 'https://chat.hackint.org/?join=voc-lounge'} [Web-IRC]
       %a{href: 'https://matrix.to/#/#voc-lounge:hackint.org'} [Matrix]
   %p Contact for other questions about this site:
   %ul


### PR DESCRIPTION
The old webirc service is being replace by chat.hackint.org.