### PR TITLE
Add translated flag to recordings, skip in RSS

### DIFF
--- a/app/helpers/frontend/event_recording_filter.rb
+++ b/app/helpers/frontend/event_recording_filter.rb
@@ -14,7 +14,7 @@ module Frontend
     end
 
     def filter(event)
-      recordings = event.recordings
+      recordings = event.recordings.where(translated: false)
       @recordings = if @target_mime_type
                       if MimeType.is_video(@target_mime_type)
                         recordings.without_slides.by_mime_type(@target_mime_type)

--- a/db/migrate/20250120233533_add_translated_to_recordings.rb
+++ b/db/migrate/20250120233533_add_translated_to_recordings.rb
@@ -1,0 +1,11 @@
+class AddTranslatedToRecordings < ActiveRecord::Migration[7.2]
+  def up
+    add_column :recordings, :translated, :boolean, default: false, null: false
+
+    execute "UPDATE recordings SET translated = true WHERE folder LIKE '%transla%'"
+  end
+
+  def down
+    remove_column :recordings, :translated
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_30_111051) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_20_233533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -150,6 +150,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_30_111051) do
     t.boolean "high_quality", default: true, null: false
     t.boolean "html5", default: false, null: false
     t.string "state", limit: 255, default: "new", null: false
+    t.boolean "translated", default: false, null: false
     t.index ["event_id"], name: "index_recordings_on_event_id"
     t.index ["filename"], name: "index_recordings_on_filename"
     t.index ["mime_type"], name: "index_recordings_on_mime_type"


### PR DESCRIPTION
For now, guessing the value from the folder.
Detects 'opus-translation' and 'mp3-translated'.