### PR TITLE
Changes legacy docker-compose to current docker compose command

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ Then, clone this repository, make it your working directory, and run the followi
 bin/docker-dev-up
 ```
 
-You can now reach the voctoweb frontend at `http://localhost.c3voc.de/`. The backend is at `http://localhost.c3voc.de/admin`, with the default username `admin@example.org` and the password `media123`. You can stop the running containers using *Ctrl-C*. To start them again, just run `docker-compose up`.
+You can now reach the voctoweb frontend at `http://localhost.c3voc.de/`. The backend is at `http://localhost.c3voc.de/admin`, with the default username `admin@example.org` and the password `media123`. You can stop the running containers using *Ctrl-C*. To start them again, just run `docker compose up`.
 
-The whole application directory is mounted into the containers, so all changes you make to the files are reflected inside the application automatically. To run commands inside the voctoweb container, run `docker-compose run voctoweb $COMMAND`. If you ever need to rebuild the containers (because of new dependencies, for example), run the `docker-compose build` command again.
+The whole application directory is mounted into the containers, so all changes you make to the files are reflected inside the application automatically. To run commands inside the voctoweb container, run `docker compose run voctoweb $COMMAND`. If you ever need to rebuild the containers (because of new dependencies, for example), run the `docker compose build` command again.
 
 Image and video files in `docker/content` are tried first, if missing live data from media.ccc.de is used.
 

--- a/bin/docker-dev-up
+++ b/bin/docker-dev-up
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-docker-compose build
-docker-compose up -d postgres
-docker-compose run voctoweb rake db:setup
-docker-compose run voctoweb bin/update-data
-docker-compose up voctoweb
+docker compose build
+docker compose up -d postgres
+docker compose run --remove-orphans voctoweb rake db:setup
+docker compose run --remove-orphans voctoweb bin/update-data
+docker compose up voctoweb


### PR DESCRIPTION
`compose` is for some time now being called with [`docker compose`](https://docs.docker.com/reference/cli/docker/compose/) and not `docker-compose`. This PR changes all the docker commands and references in the README.md. Since multiple calls of `bin/docker-dev-up` left me with dangling containers I added the `--remove-orphans` to clean up the unused containers. 