### PR TITLE
fix player layout for different video aspect ratios

### DIFF
--- a/app/helpers/frontend/application_helper.rb
+++ b/app/helpers/frontend/application_helper.rb
@@ -107,7 +107,7 @@ module Frontend
     end
 
     def stretching
-      'responsive'
+      'none'
     end
   end
 end


### PR DESCRIPTION
See http://media.ccc.de/v/c3voc-56368-komm-in-die-gruppe-backstagepass. Page layout is not utterly broken any more with "stretching mode" set to `none` instead of `responsive`. Other videos still look fine as well in different screen widths.