### PR TITLE
Podcast clients don't show svg images, expect png

### DIFF
--- a/lib/feeds/podcast_generator.rb
+++ b/lib/feeds/podcast_generator.rb
@@ -46,8 +46,8 @@ module Feeds
       # category.new_category.text = "Technology"
       maker.channel.itunes_categories.new_category.text = 'Technology'
 
-      # TODO png/jpg?
-      maker.image.url = @config.logo_image
+      # channel artwork
+      maker.image.url = @config.logo_image.sub(/\.svg$/, '.png')
       maker.image.title = @config.channel_title
       maker.channel.itunes_author = @config.channel_owner
       maker.channel.itunes_owner.itunes_name = @config.channel_owner
@@ -79,6 +79,9 @@ module Feeds
       item.itunes_subtitle = event.subtitle if event.subtitle.present?
       item.itunes_author = event.persons.join(', ') if event.persons.present?
       item.pubDate = event.date.to_s if event.date.present?
+
+      # Add episode artwork for podcast clients (supports PNG/JPG)
+      item.itunes_image = event.thumb_url if event.thumb_url.present?
 
       item.enclosure.url = recording.url
       item.enclosure.length = size_to_bytes(recording.size || 0)

--- a/test/lib/feeds/podcast_generator_test.rb
+++ b/test/lib/feeds/podcast_generator_test.rb
@@ -12,5 +12,18 @@ module Feeds
         output = feed.generate(events, &:preferred_recording)
       }
     end
+
+    test 'includes itunes:image for episodes with thumbnails' do
+      feed = PodcastGenerator.new(title: 'test-title', channel_summary: 'test-summary', logo_image: 'http://example.com/logo.png')
+
+      event = create(:event_with_recordings)
+      event.update(thumb_filename: 'test-thumb.png')
+      events = Frontend::Event.where(id: event.id)
+
+      output = feed.generate(events, &:preferred_recording)
+
+      assert_includes output, '<itunes:image'
+      assert_includes output, 'test-thumb.png'
+    end
   end
 end


### PR DESCRIPTION
Podcast clients don't show feed image if SVG. Podcast items are lacking an image.