### PR TITLE
Fix video scaling and overflow issues by enabling responsive stretching

### DIFF
--- a/app/assets/stylesheets/frontend/shared/_videoplayer.scss
+++ b/app/assets/stylesheets/frontend/shared/_videoplayer.scss
@@ -46,8 +46,15 @@
 @include video-player-size(1920px);
 
 .video.player, div[data-player] {
+  width: 100%;
   height: 54.5vw;
   max-height: 576px;
+
+  .mejs__container,
+  video {
+    width: 100% !important;
+    height: 100% !important;
+  }
 }
 .video.player[data-aspect-ratio='4:3'] {
   height: 72vw;

--- a/app/helpers/frontend/application_helper.rb
+++ b/app/helpers/frontend/application_helper.rb
@@ -107,7 +107,7 @@ module Frontend
     end
 
     def stretching
-      'none'
+      'responsive'
     end
   end
 end


### PR DESCRIPTION
This PR restores and fixes the video player's scaling behavior, specifically addressing the issue where the video would fail to rescale correctly after exiting fullscreen or when resizing the viewport.

<img width="1345" height="1141" alt="image" src="https://github.com/user-attachments/assets/8d4c0648-a91e-4836-91e0-a9fb0e93556e" />

### How to reproduce

1. Open any video event page.
2. Enter fullscreen mode.
3. Exit fullscreen mode.
4. The video feed remains at fullscreen dimensions, resulting in only the top-left corner being visible within the player container on the page.
5. Alternatively, resize the browser window and observe that the video element does not scale down to fit narrower viewports, causing horizontal overflow.

### Changes
* Enabled `responsive` stretching: Reverted the change from #841 which set stretching to `none`. Using `none` prevented MediaElement.js from correctly managing the internal video element's dimensions during layout changes.
* CSS layout constraints: Added `width: 100%` to the video player container and enforced `100% !important` width and height on the internal MediaElement containers (`.mejs__container`) and the video element. This ensures the player always respects its parent container's bounds and fixes the overflow issues that #841 tried to address.

### Validation
I tested the changes with a local dev setup for both horizontal and vertical videos. Both video types scaled correctly.