### PR TITLE
Move event.tags/.persons from YAML to psql ARRAY

### DIFF
--- a/app/controllers/frontend/conferences_controller.rb
+++ b/app/controllers/frontend/conferences_controller.rb
@@ -31,7 +31,7 @@ module Frontend
       @conference = Frontend::Conference.find_by!(acronym: params[:acronym]) unless @conference
       if params[:tag]
         @tag = params[:tag]
-        @events = @conference.events.includes(:conference).reorder(sort_param).select { |event| event.tags.include? @tag }
+        @events = @conference.events.includes(:conference).reorder(sort_param).select { |event| event.structured_tags.include? @tag }
       else
         @events = @conference.events.includes(:conference).reorder(sort_param)
       end

--- a/app/controllers/frontend/tags_controller.rb
+++ b/app/controllers/frontend/tags_controller.rb
@@ -5,7 +5,7 @@ module Frontend
       raise ActiveRecord::RecordNotFound unless @tag
 
       # TODO native postgresql query?
-      @events = Frontend::Event.all.select { |event| event.tags.include? @tag }
+      @events = Frontend::Event.all.where("? = ANY (structured_tags)", @tag)
       respond_to { |format| format.html }
     end
   end

--- a/app/helpers/frontend/application_helper.rb
+++ b/app/helpers/frontend/application_helper.rb
@@ -48,8 +48,8 @@ module Frontend
     end
 
     def keywords
-      if @event&.tags
-        [@event.tags, I18n.t('custom.header.keywords')].join(', ')
+      if @event&.structured_tags
+        [@event.structured_tags, I18n.t('custom.header.keywords')].join(', ')
       else
         I18n.t('custom.header.keywords')
       end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -108,24 +108,24 @@ class Event < ApplicationRecord
 
   # active admin and serialized fields workaround:
   def persons_raw
-    persons.join("\n") unless persons.nil?
+    structured_persons.join("\n") unless structured_persons.nil?
   end
 
   # active admin and serialized fields workaround:
   def persons_raw=(values)
-    self.persons = []
-    self.persons = values.split("\n").map(&:strip)
+    self.structured_persons = []
+    self.structured_persons = values.split("\n").map(&:strip)
   end
 
   # active admin and serialized fields workaround:
   def tags_raw
-    tags.join("\n") unless tags.nil?
+    structured_tags.join("\n") unless structured_tags.nil?
   end
 
   # active admin and serialized fields workaround:
   def tags_raw=(values)
-    self.tags = []
-    self.tags = values.split("\n").map(&:strip)
+    self.structured_tags = []
+    self.structured_tags = values.split("\n").map(&:strip)
   end
 
   def duration_from_recordings
@@ -148,12 +148,12 @@ class Event < ApplicationRecord
   end
 
   def persons_text
-    if persons.length.zero?
+    if structured_persons.length.zero?
       'n/a'
-    elsif persons.length == 1
-      persons[0]
+    elsif structured_persons.length == 1
+      structured_persons[0]
     else
-      persons = self.persons[0..-3] + [self.persons[-2..-1].join(' and ')]
+      persons = self.structured_persons[0..-3] + [self.structured_persons[-2..-1].join(' and ')]
       persons.join(', ')
     end
   end

--- a/app/views/frontend/events/playlist.html.haml
+++ b/app/views/frontend/events/playlist.html.haml
@@ -38,7 +38,7 @@
       = @playlist.lead_event.title
   
     %p.persons
-      = render partial: 'frontend/shared/event_persons', locals: { persons: @playlist.lead_event.persons }
+      = render partial: 'frontend/shared/event_persons', locals: { persons: @playlist.lead_event.structured_persons }
       
     %p
       = simple_format(@playlist.lead_event.description, class: :description)

--- a/app/views/frontend/events/show.html.haml
+++ b/app/views/frontend/events/show.html.haml
@@ -16,7 +16,7 @@
   %meta{property: 'twitter:player', content: oembed_event_url(slug: @event.slug)}
   %meta{property: 'twitter:player:height', content: '480'}
   %meta{property: 'twitter:player:width', content: '854'}
-  - @event.persons.each do |speaker|
+  - @event.structured_persons.each do |speaker|
     %meta{property: 'author', content: speaker}
   %link{rel: 'canonical', href: event_path(slug: @event.slug)}
   - if @event.preferred_recording
@@ -79,7 +79,7 @@
           = @event.subtitle
 
     %p.persons
-      = render partial: 'frontend/shared/event_persons', locals: { persons: @event.persons }
+      = render partial: 'frontend/shared/event_persons', locals: { persons: @event.structured_persons }
 
     - if not @event.recordings.video.present? and @event.relive_present?
       .alert.alert-info.relive-notice
@@ -93,8 +93,8 @@
         .kiosk
         = render partial: 'frontend/shared/player_video' + @player, locals: video_player_ivars
 
-      - if !@event.tags.nil? && @event.tags.length > 3 
-        - @event.tags[3,2].reverse.each do |tag|
+      - if !@event.structured_tags.nil? && @event.structured_tags.length > 3
+        - @event.structured_tags[3,2].reverse.each do |tag|
           != link_for(@conference, tag)
 
       Playlists:
@@ -175,10 +175,10 @@
     .share
       = render partial: 'frontend/shared/embedshare', locals: { event: @event }
 
-    - if @event.tags.present?
+    - if @event.structured_tags.present?
       %h3 Tags
       .tags
-        - @event.tags.each do |tag|
+        - @event.structured_tags.each do |tag|
           - if tag =~ /^[0-9]+/
             != link_for_global(tag)
           - else

--- a/app/views/frontend/shared/_event_metadata.haml
+++ b/app/views/frontend/shared/_event_metadata.haml
@@ -11,10 +11,10 @@
     %div.timelens{data: {timeline: event.timeline_url, thumbnails: event.thumbnails_url, slug: event.slug, duration: event.duration, lazy: "yes"}}
 
   %ul.metadata
-    - if !event.tags.nil? && event.tags.length > 3 
+    - if !event.structured_tags.nil? && event.structured_tags.length > 3
       %li.tags
         %span.tags
-        - event.tags[3,2].each do |tag|
+        - event.structured_tags[3,2].each do |tag|
           != link_for(event.conference, tag)
     %li.duration.digits
       %span.icon.icon-clock-o
@@ -26,7 +26,7 @@
       %span.icon.icon-eye{title: "#{delimited_views_count(event.view_count)} views"}
       = human_readable_views_count(event.view_count)
     %li.persons
-      = render partial: 'frontend/shared/event_persons', locals: { persons: event.persons }
+      = render partial: 'frontend/shared/event_persons', locals: { persons: event.structured_persons }
     - if show_conference && event.conference.present?
       .conference
         %a{href: conference_path(acronym: event.conference.acronym)}

--- a/app/views/frontend/shared/_player_playlist_audio.haml
+++ b/app/views/frontend/shared/_player_playlist_audio.haml
@@ -5,7 +5,7 @@
             title: event.title,
             data: { id: event.id,
                     title: event.title.truncate(30),
-                    persons: event.persons.join(', '),
+                    persons: event.structured_persons.join(', '),
                     lang: recording.language,
                     mep: { description: event.description } }}
 

--- a/app/views/frontend/shared/_player_playlist_video.haml
+++ b/app/views/frontend/shared/_player_playlist_video.haml
@@ -11,7 +11,7 @@
             data: { id: event.id,
                     title: event.title,
                     poster: event.poster_url,
-                    persons: event.persons.join(', '),
+                    persons: event.structured_persons.join(', '),
                     lang: recording.language,
                     quality: recording.quality_label,
                     mep: { description: event.description } }}

--- a/app/views/public/shared/_event.json.jbuilder
+++ b/app/views/public/shared/_event.json.jbuilder
@@ -1,4 +1,6 @@
-json.extract! event, :guid, :title, :subtitle, :slug, :link, :description, :original_language, :persons, :tags, :view_count, :promoted, :date, :release_date, :updated_at
+json.extract! event, :guid, :title, :subtitle, :slug, :link, :description, :original_language, :view_count, :promoted, :date, :release_date, :updated_at
+json.tags event.structured_tags
+json.persons event.structured_persons
 json.length event.duration
 json.duration event.duration
 json.thumb_url event.get_thumb_url

--- a/db/migrate/20260110233200_event_tags_as_json.rb
+++ b/db/migrate/20260110233200_event_tags_as_json.rb
@@ -1,0 +1,12 @@
+class EventTagsAsJson < ActiveRecord::Migration[7.2]
+  def up
+    add_column :events, :structured_tags, :string, array: true, default: [], null: false
+    Event.all.each { |event|
+      event.update_attribute(:structured_tags, event.tags)
+    }
+  end
+
+  def down
+    remove_column :events, :structured_tags
+  end
+end

--- a/db/migrate/20260111004100_event_persons_as_json.rb
+++ b/db/migrate/20260111004100_event_persons_as_json.rb
@@ -1,0 +1,12 @@
+class EventPersonsAsJson < ActiveRecord::Migration[7.2]
+  def up
+    add_column :events, :structured_persons, :string, array: true, default: [], null: false
+    Event.all.each { |event|
+      event.update_attribute(:structured_persons, event.persons)
+    }
+  end
+
+  def down
+    remove_column :events, :structured_persons
+  end
+end

--- a/db/migrate/20260111131000_event_remove_unstructured_fields.rb
+++ b/db/migrate/20260111131000_event_remove_unstructured_fields.rb
@@ -1,0 +1,15 @@
+class EventRemoveUnstructuredFields < ActiveRecord::Migration[7.2]
+  def up
+    remove_column :events, :tags
+    remove_column :events, :persons
+  end
+
+  def down
+    add_column :events, :tags, :string, default: "", null: false
+    add_column :events, :persons, :string, default: "", null: false
+    Event.all.each { |event|
+      event.update_attribute(:persons, event.structured_persons)
+      event.update_attribute(:tags, event.structured_tags)
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_20_233533) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_11_131000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,10 +93,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_20_233533) do
     t.datetime "date", precision: nil
     t.text "description"
     t.string "link"
-    t.text "persons"
     t.string "slug"
     t.string "subtitle"
-    t.text "tags"
     t.datetime "release_date", precision: nil
     t.boolean "promoted"
     t.integer "view_count", default: 0
@@ -108,6 +106,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_20_233533) do
     t.string "thumbnails_filename", default: ""
     t.string "doi"
     t.string "notes"
+    t.string "structured_tags", default: [], null: false, array: true
+    t.string "structured_persons", default: [], null: false, array: true
     t.index ["conference_id"], name: "index_events_on_conference_id"
     t.index ["guid"], name: "index_events_on_guid"
     t.index ["metadata"], name: "index_events_on_metadata", using: :gin

--- a/lib/feeds/podcast_generator.rb
+++ b/lib/feeds/podcast_generator.rb
@@ -77,7 +77,7 @@ module Feeds
       item.pubDate = event.created_at.to_s
 
       item.itunes_subtitle = event.subtitle if event.subtitle.present?
-      item.itunes_author = event.persons.join(', ') if event.persons.present?
+      item.itunes_author = event.structured_persons.join(', ') if event.structured_persons.present?
       item.pubDate = event.date.to_s if event.date.present?
 
       # Add episode artwork for podcast clients (supports PNG/JPG)

--- a/test/controllers/api/events_controller_test.rb
+++ b/test/controllers/api/events_controller_test.rb
@@ -74,8 +74,8 @@ class Api::EventsControllerTest < ActionController::TestCase
     assert_equal 'qwerty', event.guid
     assert_equal 'best_event', event.slug
     assert_equal 'Event?', event.title
-    assert_equal %w(p q r), event.persons
-    assert_equal %w(t u v), event.tags
+    assert_equal %w(p q r), event.structured_persons
+    assert_equal %w(t u v), event.structured_tags
   end
 
   test 'when event create fails it should return json errors' do

--- a/test/controllers/frontend/search_controller_test.rb
+++ b/test/controllers/frontend/search_controller_test.rb
@@ -56,7 +56,7 @@ class Frontend::SearchControllerTest < ActionController::TestCase
       assert_response :success
       
       assigns(:events).each do |event|
-        assert_includes event.persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
+        assert_includes event.structured_persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
       end
     end
 
@@ -67,7 +67,7 @@ class Frontend::SearchControllerTest < ActionController::TestCase
       assert_response :success
       events = assigns(:events)
       events.each do |event|
-        assert_includes event.persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
+        assert_includes event.structured_persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
       end
       events.map(&:date).each_cons(2) do |a, b|
         assert a <= b, "Dates are not in ascending order: #{a} should be before #{b}"
@@ -81,7 +81,7 @@ class Frontend::SearchControllerTest < ActionController::TestCase
       assert_response :success
       events = assigns(:events)
       events.each do |event|
-        assert_includes event.persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
+        assert_includes event.structured_persons, 'Alice', "Expected 'Alice' to be in the persons array for event #{event.title}"
       end
       events.map(&:date).each_cons(2) do |a, b|
         assert a >= b, "Dates are not in ascending order: #{a} should be before #{b}"

--- a/test/integration/events_api_test.rb
+++ b/test/integration/events_api_test.rb
@@ -39,6 +39,6 @@ class EventsApiTest < ActionDispatch::IntegrationTest
     event = Event.where(guid: '12345').first
     assert_equal 'http://link.to', event.link
     assert_equal 'chaosknoten.jpg', event.thumb_filename
-    assert_equal %w[a b c], event.persons
+    assert_equal %w[a b c], event.structured_persons
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -28,8 +28,8 @@ class EventTest < ActiveSupport::TestCase
   test "should save event with persons" do
     e = build(:event)
     e.subtitle = "subtitle"
-    e.persons << "name1"
-    e.persons << "name2"
+    e.structured_persons << "name1"
+    e.structured_persons << "name2"
 
     assert_difference 'Event.count' do
       e.save!


### PR DESCRIPTION
This allows native postgres queries based on tags and people.

e.g., the /tags/ endpoint now only has to fetch matching events instead of the entire database, improving latency by 106x and RAM usage by >99%.