### PR TITLE
Remove link to lottery scam site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Voctoweb is a rails application that provides a “YouTube like” user interfac
 
 The newest API endpoint is at https://media.ccc.de/graphql, implementing a GraphQL endpoint with Apollo Federation. This allows clients to only request the attributes they need, while all data needed per screen can be fetched in a single request. We tried to clean up the type names and call talks `lecture` and files `resources` (previously known as recordings). Please create issues if you are missing anything.
 
-Example query: https://graphqlbin.com/v2/nOWBC7
 ``` graphql
 query LectureQueryExample {
   lectureBySlug(slug: "36c3-10652-bahnmining_-_punktlichkeit_ist_eine_zier") {


### PR DESCRIPTION
It seems graphqlbin.com doesn't exist anymore, and someone snatched the domain.