### PR TITLE
Update apps section of about page

### DIFF
--- a/app/views/frontend/home/about.haml
+++ b/app/views/frontend/home/about.haml
@@ -114,8 +114,8 @@
     - LG WebOS: 
       - [WebOS_media_ccc_de](https://github.com/raben2/WebOS_media_ccc_de). Wrapper to the media.ccc.de frontend.
       - [CCCBib](https://github.com/volkovmqx/cccbib). Experimental media library application for webOS.
-    - AppleTV:
-      - [CCC-TV](https://github.com/ccc-ffm/CCC-TV). Not all talks available due to Apple Inc. interpretation of their [app store review guidelines](https://developer.apple.com/app-store/review/guidelines/)
+    - Apple TV, iOS, macOS, visionOS:
+      - [HackerTube](https://github.com/mbernson/HackerTube). App for Apple TV, iOS/iPadOS, macOS and visionOS.
     - Kodi:
       - [plugin.video.media-ccc-de](https://github.com/voc/plugin.video.media-ccc-de#mediacccde-for-kodi) Official Kodi plugin
     - Dreambox:


### PR DESCRIPTION
I've written the open source app 'HackerTube' for viewing media.ccc.de on Apple TV, iOS and other Apple platforms, which I'd like to add to the 'apps' section.

The app has been approved by Apple (it's been in the App Store for over two years already) and it offers full access to the media.ccc.de catalogue. I'm updating it every now and then.

This PR also removes the reference to https://github.com/ccc-ffm/CCC-TV since this app has not seen a commit in 8 years and is not generally available. 
