### PR TITLE
Fix bare HomeController constant reference in home view

### DIFF
--- a/app/views/frontend/home/index.html.haml
+++ b/app/views/frontend/home/index.html.haml
@@ -75,9 +75,9 @@
                             = event.display_date
 
 
-              - if conference.events.count > HomeController::EVENT_LIMIT
+              - if conference.events.count > Frontend::HomeController::EVENT_LIMIT
                 %a.more{href: conference_path(acronym: conference.acronym)}
-                  Show #{conference.events.count - HomeController::EVENT_LIMIT} more videos from #{conference.display_name}
+                  Show #{conference.events.count - Frontend::HomeController::EVENT_LIMIT} more videos from #{conference.display_name}
 
   .row
     - if @news.present?

--- a/test/controllers/frontend/home_controller_test.rb
+++ b/test/controllers/frontend/home_controller_test.rb
@@ -6,6 +6,16 @@ module Frontend
       get :index
       assert_response :success
     end
+
+    test "should get index with a conference that has more events than the limit" do
+      conference = create(:conference)
+      (Frontend::HomeController::EVENT_LIMIT + 1).times { create(:event, conference: conference) }
+
+      get :index
+      assert_response :success
+      assert_includes @response.body, "more videos from #{conference.display_name}"
+    end
+
     test "should get about" do
       get :about
       assert_response :success


### PR DESCRIPTION
The Frontend:: model namespace removal accidentally stripped the namespace from a controller constant reference too: the "more videos" link used HomeController::EVENT_LIMIT, but only Frontend::HomeController exists. This only raised once a conference had more events than EVENT_LIMIT, a path the existing test never exercised.

Add a test that seeds a conference past the limit so this branch is covered going forward.