### PR TITLE
Hide conferences without recordings from public api by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ query LectureQueryExample {
 The public API provides a programmatic access to the data behind media.ccc.de. Consumers of this API are typically player apps for different ecosystems, see https://media.ccc.de/about.html#apps for a 'full' list. The whole API is "discoverable" starting from https://api.media.ccc.de/public/conferences ; Available methods:
 
     /public/conferences
+    /public/conferences?include_empty=true
     /public/conferences/:acronym
     /public/conferences/:id
     /public/events
@@ -57,7 +58,10 @@ Example:
 curl -H "CONTENT-TYPE: application/json" http://localhost:3000/public/conferences
 ```
 
-The resulting JSON will contain URLs to each of the individual conferences.
+The resulting JSON will contain URLs to each of the individual conferences. By
+default only conferences that have at least one recorded event are listed
+(matching what media.ccc.de shows). Pass `?include_empty=true` to also include
+conferences that do not have any associated events yet.
 
 Additionally the API for events and recordings uses RFC-5988 HTTP header based pagination to reduce the server load.
 

--- a/app/controllers/frontend/conferences_controller.rb
+++ b/app/controllers/frontend/conferences_controller.rb
@@ -56,8 +56,11 @@ module Frontend
       tree.sort_folders(folders)
     end
 
+    # Note: this filters on recorded events (with a recording), distinct from
+    # Conference.with_events, which filters on released events
+    # (event_last_released_at) which may not have any associated recordings.
     def conferences_with_events
-      Conference.where('downloaded_events_count > 0')
+      Conference.with_recorded_events
     end
 
     def sort_param

--- a/app/controllers/public/conferences_controller.rb
+++ b/app/controllers/public/conferences_controller.rb
@@ -5,10 +5,21 @@ module Public
 
     # GET /public/conferences
     # GET /public/conferences.json
+    #
+    # By default only conferences that have at least one recorded event are
+    # returned (matching what the web frontend shows). Pass ?include_empty=true
+    # to also include conferences without any associated events.
     def index
-      key = Conference.all.maximum(:updated_at)
-      @conferences = Rails.cache.fetch([:public, :conferences, key], race_condition_ttl: 10) do
-        Conference.all
+      include_empty = ActiveModel::Type::Boolean.new.cast(params[:include_empty])
+      conferences = include_empty ? Conference.all : Conference.with_recorded_events
+
+      # The listed set can change without any conference row changing: recording
+      # an event updates downloaded_events_count via update_column, which skips
+      # updated_at. The result count busts the cache when a conference gains or
+      # loses events; include_empty keeps the two variants cached separately.
+      key = [:public, :conferences, include_empty, conferences.maximum(:updated_at), conferences.count]
+      @conferences = Rails.cache.fetch(key, race_condition_ttl: 10) do
+        conferences.to_a
       end
       respond_to { |format| format.json }
     end

--- a/app/models/conference.rb
+++ b/app/models/conference.rb
@@ -32,6 +32,11 @@ class Conference < ApplicationRecord
     where('(streaming ->> :key)::boolean', key: 'isCurrentlyStreaming')
   }
 
+  # Conferences that have at least one recorded event (i.e. with a recording).
+  # Note: distinct from .with_events above, which filters on released events
+  # (event_last_released_at) which may not have any associated recordings.
+  scope :with_recorded_events, -> { where('downloaded_events_count > 0') }
+
   validates :acronym, :slug, presence: true
   validates :acronym, :slug, uniqueness: true
   validates :slug, format: { with: %r{\A\w[\w-]*(?:/[\w-]+)*\z} }

--- a/test/controllers/public/conferences_controller_test.rb
+++ b/test/controllers/public/conferences_controller_test.rb
@@ -10,6 +10,28 @@ class Public::ConferencesControllerTest < ActionController::TestCase
     refute_empty json['conferences'][0]['url']
   end
 
+  test "index excludes conferences without events by default" do
+    with_events = create :conference_with_recordings
+    without_events = create :conference
+
+    get :index, format: :json
+    assert_response :success
+    acronyms = JSON.parse(response.body)['conferences'].map { |c| c['acronym'] }
+    assert_includes acronyms, with_events.acronym
+    refute_includes acronyms, without_events.acronym
+  end
+
+  test "index includes empty conferences with include_empty=true" do
+    with_events = create :conference_with_recordings
+    without_events = create :conference
+
+    get :index, params: { include_empty: 'true' }, format: :json
+    assert_response :success
+    acronyms = JSON.parse(response.body)['conferences'].map { |c| c['acronym'] }
+    assert_includes acronyms, with_events.acronym
+    assert_includes acronyms, without_events.acronym
+  end
+
   test "should get show" do
     conference = create :conference_with_recordings
     get :show, params: { id: conference.id }, format: :json


### PR DESCRIPTION
Hide conferences without recordings from `/public/conferences` by default, pass `?include_empty=true` to include them.