### PR TITLE
Upgrade Elasticsearch to 8.19.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
         ports:
           - 5432:5432
       elasticsearch:
-        image: elasticsearch:6.8.17
+        image: elasticsearch:8.19.16
+        env:
+          discovery.type: single-node
+          xpack.security.enabled: false
         ports:
           - 9200:9200
 

--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,10 @@ gem 'rss'
 gem 'kaminari'
 
 gem 'pg', group: :postgresql
-gem 'elasticsearch-model', '~> 6.1.1'
-gem 'elasticsearch-rails', '~> 6.1.0'
+
+# needs to match server version
+gem 'elasticsearch-model', '~> 8.0'
+gem 'elasticsearch-rails', '~> 8.0'
 
 # Use SCSS for stylesheets
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,19 +171,20 @@ GEM
       railties (>= 6.1)
     drb (2.2.3)
     ed25519 (1.4.0)
-    elasticsearch (6.8.3)
-      elasticsearch-api (= 6.8.3)
-      elasticsearch-transport (= 6.8.3)
-    elasticsearch-api (6.8.3)
+    elastic-transport (8.5.2)
+      faraday (< 3)
       multi_json
-    elasticsearch-model (6.1.2)
+    elasticsearch (8.19.3)
+      elastic-transport (~> 8.3)
+      elasticsearch-api (= 8.19.3)
+      ostruct
+    elasticsearch-api (8.19.3)
+      multi_json
+    elasticsearch-model (8.0.1)
       activesupport (> 3)
-      elasticsearch (~> 6)
+      elasticsearch (~> 8)
       hashie
-    elasticsearch-rails (6.1.2)
-    elasticsearch-transport (6.8.3)
-      faraday (~> 1)
-      multi_json
+    elasticsearch-rails (8.0.1)
     erb (6.0.4)
     erubi (1.13.1)
     exception_notification (5.0.1)
@@ -195,29 +196,12 @@ GEM
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (1.10.5)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.1)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.2.0)
-      multipart-post (~> 2.0)
-    faraday-net_http (1.0.2)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.4)
+    faraday (2.14.3)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     ffi (1.17.4)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -326,8 +310,9 @@ GEM
     mini_portile2 (2.8.9)
     minitest (5.27.0)
     multi_json (1.21.1)
-    multipart-post (2.4.1)
     mutex_m (0.3.0)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
     net-imap (0.6.4.1)
       date
       net-protocol
@@ -619,6 +604,7 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     uniform_notifier (1.18.0)
+    uri (1.1.1)
     useragent (0.16.11)
     validate_email (0.1.6)
       activemodel (>= 3.0)
@@ -667,8 +653,8 @@ DEPENDENCIES
   devise
   dotenv-rails
   ed25519
-  elasticsearch-model (~> 6.1.1)
-  elasticsearch-rails (~> 6.1.0)
+  elasticsearch-model (~> 8.0)
+  elasticsearch-rails (~> 8.0)
   exception_notification
   factory_bot_rails
   foreman

--- a/app/models/concerns/elasticsearch_event.rb
+++ b/app/models/concerns/elasticsearch_event.rb
@@ -8,7 +8,6 @@ module ElasticsearchEvent
     include Elasticsearch::Model::Callbacks unless ENV['SKIP_ELASTICSEARCH']
 
     index_name "media-event-#{Rails.env}"
-    document_type 'event'
 
     def as_indexed_json(_options = {})
       as_json(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,12 +40,14 @@ services:
     ports:
       - "5432:5432"
   elasticsearch:
-    image: elasticsearch:6.8.6
+    image: elasticsearch:8.19.16
     platform: linux/amd64
     ports:
       - "9200:9200"
     environment:
       - cluster.name=docker-cluster
+      - discovery.type=single-node
+      - xpack.security.enabled=false
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - http.cors.enabled=true


### PR DESCRIPTION
Bump elasticsearch-model/elasticsearch-rails from 6.1 to 8.0 and the dev/CI Docker images from 6.8 to 8.19.16. Drop document_type, which elasticsearch-model 8.x no longer exposes since Elasticsearch removed mapping types in 7.0. ES8 enables security by default, so disable it via xpack.security.enabled=false for dev/CI, which talk to a trusted single-node instance over plain HTTP.

As a side effect, elasticsearch-model 8.x drops the old elasticsearch-transport gem's hard `faraday ~> 1` pin in favor of elastic-transport's `faraday < 3`, so faraday floats up to 2.14.3. The newer elastic-transport also fixes the adapter auto-detection bug that previously misdetected :httpclient when the unrelated httpclient gem was loaded, so no client adapter override is needed.